### PR TITLE
Version 3.10.2 with arch x64 not found, changing to 3.10.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
       - uses: actions/checkout@v2
 
       # Set up Python 3.10.2 environment
-      - name: Set up Python 3.10
+      - name: Set up Python 3.10.4
         uses: actions/setup-python@v1
         with:
-          python-version: "3.10.2"
+          python-version: "3.10.4"
 
       # Install dependencies
       - name: Install dependencies


### PR DESCRIPTION
Version 3.10.2 with arch x64 not found, changing to 3.10.4
* * *

**GitHub Issue**: N/A

# What does this Pull Request do?
Fixes GitHub Actions that were failing due to not being able to install the older version of Python

# How should this be tested?

Confim GitHub Actions pass

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n/a
- integration tests? n/a

# Interested parties
@ives1227 @GPortas 
