### PR TITLE
MQs SSL Enabled if statement uncommented

### DIFF
--- a/app/common/infrastructure/mq/stomp_interactor.py
+++ b/app/common/infrastructure/mq/stomp_interactor.py
@@ -48,8 +48,8 @@ class StompInteractor(ABC):
                 keepalive=True
             )
 
-            # if mq_ssl_enabled == 'True':
-            connection.set_ssl([(mq_host, mq_port)])
+            if mq_ssl_enabled == 'True':
+                connection.set_ssl([(mq_host, mq_port)])
 
             connection.connect(
                 mq_user,


### PR DESCRIPTION
**SSL Enabled if statement uncommented.**
* * *

**GitHub Issue**: ([link](https://app.zenhub.com/workspaces/hdc-62163f60fb08c60011fa4795/issues/harvard-lts/hdc/166))

# What does this Pull Request do?
Uncomments SSL enabled if statement for MQ connections. 

We discovered that the related error was caused by an incorrect environment variable assignment in the dev environment. By assigning a correct value 'True', the ssl must be set correctly.

# How should this be tested?
N/A

# Test coverage
N/A

# Interested parties
@jessjass @ives1227 

Keyword: resolved