### PR TITLE
Published messages including original_queue and retry_count fields

### DIFF
--- a/test/functional/test.env.example
+++ b/test/functional/test.env.example
@@ -24,8 +24,8 @@ MQ_TRANSFER_USER=admin
 MQ_TRANSFER_PASSWORD=admin
 # False for local test environment
 MQ_TRANSFER_SSL_ENABLED=False
-MQ_TRANSFER_QUEUE_TRANSFER_READY=/queue/test-transfer-ready
-MQ_TRANSFER_QUEUE_TRANSFER_STATUS=/queue/test-dropbox-transfer-status
+MQ_TRANSFER_QUEUE_TRANSFER_READY=/queue/test-functional-transfer-ready
+MQ_TRANSFER_QUEUE_TRANSFER_STATUS=/queue/test-functional-dropbox-transfer-status
 
 # Process MQ
 MQ_PROCESS_HOST=test_activemq
@@ -34,5 +34,5 @@ MQ_PROCESS_USER=admin
 MQ_PROCESS_PASSWORD=admin
 # False for local test environment
 MQ_PROCESS_SSL_ENABLED=False
-MQ_PROCESS_QUEUE_PROCESS_READY=/queue/test-dims-data-ready
-MQ_PROCESS_QUEUE_PROCESS_STATUS=/queue/test-drs-ingest-status
+MQ_PROCESS_QUEUE_PROCESS_READY=/queue/test-functional-dims-data-ready
+MQ_PROCESS_QUEUE_PROCESS_STATUS=/queue/test-functional-drs-ingest-status

--- a/test/integration/common/infrastructure/mq/publishers/stomp_publisher_integration_test_base.py
+++ b/test/integration/common/infrastructure/mq/publishers/stomp_publisher_integration_test_base.py
@@ -1,18 +1,18 @@
+import json
 import time
-from abc import ABC
+from abc import ABC, abstractmethod
 
 import stomp
 from stomp.utils import Frame
 
 from test.integration.common.infrastructure.mq.stomp_integration_test_base import StompIntegrationTestBase
 
-test_message_received = False
-
 
 class StompPublisherIntegrationTestBase(StompIntegrationTestBase, ABC):
 
     def setUp(self) -> None:
         super().setUp()
+        self.received_frame = None
         self.connection = self._create_subscribed_mq_connection()
 
     def tearDown(self) -> None:
@@ -20,21 +20,41 @@ class StompPublisherIntegrationTestBase(StompIntegrationTestBase, ABC):
 
     def _create_subscribed_mq_connection(self) -> stomp.Connection:
         connection = self._create_mq_connection()
-        connection.subscribe(destination=self._get_queue_name(), id=1)
-        connection.set_listener('', TestConnectionListener())
+        connection.subscribe(destination=self._get_queue_name(), id=self._get_queue_name() + "-test-connection")
+        connection.set_listener(self._get_queue_name() + "-test-listener",
+                                StompPublisherIntegrationTestBase.TestConnectionListener(self))
         return connection
 
     def _await_until_message_received_or_timeout(self) -> None:
         timeout = self._get_message_await_timeout()
-        while not test_message_received and time.time() < timeout:
+        while self.received_frame is None and time.time() < timeout:
             time.sleep(1)
 
     def _assert_test_message_has_been_received(self) -> None:
-        if not test_message_received:
+        if self.received_frame is None:
             self.fail(msg="The queue did not receive the published message")
 
+        actual_headers = self.received_frame.headers
 
-class TestConnectionListener(stomp.ConnectionListener):
-    def on_message(self, frame: Frame) -> None:
-        global test_message_received
-        test_message_received = True
+        actual_original_queue_header = actual_headers['original_queue']
+        expected_original_queue_header = self._get_queue_name()
+        self.assertEqual(actual_original_queue_header, expected_original_queue_header)
+
+        actual_retry_count_header = actual_headers['retry_count']
+        expected_retry_count_header = "0"
+        self.assertEqual(actual_retry_count_header, expected_retry_count_header)
+
+        actual_body_str = self.received_frame.body
+        expected_body_str = json.dumps(self._get_expected_body())
+        self.assertEqual(actual_body_str, expected_body_str)
+
+    @abstractmethod
+    def _get_expected_body(self) -> dict:
+        pass
+
+    class TestConnectionListener(stomp.ConnectionListener):
+        def __init__(self, outer_test) -> None:
+            self.outer_test = outer_test
+
+        def on_message(self, frame: Frame) -> None:
+            self.outer_test.received_frame = frame

--- a/test/integration/common/infrastructure/mq/publishers/stomp_publisher_integration_test_base.py
+++ b/test/integration/common/infrastructure/mq/publishers/stomp_publisher_integration_test_base.py
@@ -20,9 +20,13 @@ class StompPublisherIntegrationTestBase(StompIntegrationTestBase, ABC):
 
     def _create_subscribed_mq_connection(self) -> stomp.Connection:
         connection = self._create_mq_connection()
-        connection.subscribe(destination=self._get_queue_name(), id=self._get_queue_name() + "-test-connection")
-        connection.set_listener(self._get_queue_name() + "-test-listener",
-                                StompPublisherIntegrationTestBase.TestConnectionListener(self))
+
+        subscription_id = self._get_queue_name() + "-test-connection"
+        connection.subscribe(destination=self._get_queue_name(), id=subscription_id)
+
+        listener_name = self._get_queue_name() + "-test-listener"
+        connection.set_listener(listener_name, StompPublisherIntegrationTestBase.TestConnectionListener(self))
+
         return connection
 
     def _await_until_message_received_or_timeout(self) -> None:

--- a/test/integration/common/infrastructure/mq/publishers/stomp_publisher_integration_test_base.py
+++ b/test/integration/common/infrastructure/mq/publishers/stomp_publisher_integration_test_base.py
@@ -38,19 +38,10 @@ class StompPublisherIntegrationTestBase(StompIntegrationTestBase, ABC):
         if self.received_frame is None:
             self.fail(msg="The queue did not receive the published message")
 
-        actual_headers = self.received_frame.headers
+        actual_body = json.loads(self.received_frame.body)
+        expected_body = self._get_expected_body()
 
-        actual_original_queue_header = actual_headers['original_queue']
-        expected_original_queue_header = self._get_queue_name()
-        self.assertEqual(actual_original_queue_header, expected_original_queue_header)
-
-        actual_retry_count_header = actual_headers['retry_count']
-        expected_retry_count_header = "0"
-        self.assertEqual(actual_retry_count_header, expected_retry_count_header)
-
-        actual_body_str = self.received_frame.body
-        expected_body_str = json.dumps(self._get_expected_body())
-        self.assertEqual(actual_body_str, expected_body_str)
+        self.assertDictEqual(actual_body, expected_body)
 
     @abstractmethod
     def _get_expected_body(self) -> dict:

--- a/test/integration/ingest/infrastructure/mq/publishers/test_process_ready_queue_publisher.py
+++ b/test/integration/ingest/infrastructure/mq/publishers/test_process_ready_queue_publisher.py
@@ -9,10 +9,13 @@ from test.resources.ingest.ingest_factory import create_ingest
 
 class TestProcessReadyQueuePublisher(StompPublisherIntegrationTestBase):
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.TEST_INGEST = create_ingest()
+
     def test_publish_message_happy_path(self) -> None:
         sut = ProcessReadyQueuePublisher()
-        test_ingest = create_ingest()
-        sut.publish_message(test_ingest)
+        sut.publish_message(self.TEST_INGEST)
 
         self._await_until_message_received_or_timeout()
 
@@ -29,3 +32,10 @@ class TestProcessReadyQueuePublisher(StompPublisherIntegrationTestBase):
 
     def _get_queue_name(self) -> str:
         return os.getenv('MQ_PROCESS_QUEUE_PROCESS_READY')
+
+    def _get_expected_body(self) -> dict:
+        return {
+            'package_id': self.TEST_INGEST.package_id,
+            'destination_path': os.getenv('INGEST_DESTINATION_PATH'),
+            'application_name': self.TEST_INGEST.depositing_application.value
+        }

--- a/test/integration/ingest/infrastructure/mq/publishers/test_process_ready_queue_publisher.py
+++ b/test/integration/ingest/infrastructure/mq/publishers/test_process_ready_queue_publisher.py
@@ -37,5 +37,9 @@ class TestProcessReadyQueuePublisher(StompPublisherIntegrationTestBase):
         return {
             'package_id': self.TEST_INGEST.package_id,
             'destination_path': os.getenv('INGEST_DESTINATION_PATH'),
-            'application_name': self.TEST_INGEST.depositing_application.value
+            'application_name': self.TEST_INGEST.depositing_application.value,
+            'admin_metadata': {
+                'original_queue': self._get_queue_name(),
+                'retry_count': 0
+            }
         }

--- a/test/integration/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
+++ b/test/integration/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
@@ -40,4 +40,5 @@ class TestTransferReadyQueuePublisher(StompPublisherIntegrationTestBase):
             's3_bucket_name': self.TEST_INGEST.s3_bucket_name,
             'destination_path': os.getenv('INGEST_DESTINATION_PATH'),
             'admin_metadata': self.TEST_INGEST.admin_metadata,
+            'application_name': self.TEST_INGEST.depositing_application.value
         }

--- a/test/integration/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
+++ b/test/integration/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
@@ -9,10 +9,13 @@ from test.resources.ingest.ingest_factory import create_ingest
 
 class TestTransferReadyQueuePublisher(StompPublisherIntegrationTestBase):
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.TEST_INGEST = create_ingest()
+
     def test_publish_message_happy_path(self) -> None:
         sut = TransferReadyQueuePublisher()
-        test_ingest = create_ingest()
-        sut.publish_message(test_ingest)
+        sut.publish_message(self.TEST_INGEST)
 
         self._await_until_message_received_or_timeout()
 
@@ -29,3 +32,12 @@ class TestTransferReadyQueuePublisher(StompPublisherIntegrationTestBase):
 
     def _get_queue_name(self) -> str:
         return os.getenv('MQ_TRANSFER_QUEUE_TRANSFER_READY')
+
+    def _get_expected_body(self) -> dict:
+        return {
+            'package_id': self.TEST_INGEST.package_id,
+            's3_path': self.TEST_INGEST.s3_path,
+            's3_bucket_name': self.TEST_INGEST.s3_bucket_name,
+            'destination_path': os.getenv('INGEST_DESTINATION_PATH'),
+            'admin_metadata': self.TEST_INGEST.admin_metadata,
+        }

--- a/test/integration/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
+++ b/test/integration/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
@@ -39,6 +39,7 @@ class TestTransferReadyQueuePublisher(StompPublisherIntegrationTestBase):
             's3_path': self.TEST_INGEST.s3_path,
             's3_bucket_name': self.TEST_INGEST.s3_bucket_name,
             'destination_path': os.getenv('INGEST_DESTINATION_PATH'),
-            'admin_metadata': self.TEST_INGEST.admin_metadata,
+            'admin_metadata':
+                self.TEST_INGEST.admin_metadata | {'original_queue': self._get_queue_name(), 'retry_count': 0},
             'application_name': self.TEST_INGEST.depositing_application.value
         }

--- a/test/integration/test.env.example
+++ b/test/integration/test.env.example
@@ -21,8 +21,8 @@ MQ_TRANSFER_USER=admin
 MQ_TRANSFER_PASSWORD=admin
 # False for local test environment
 MQ_TRANSFER_SSL_ENABLED=False
-MQ_TRANSFER_QUEUE_TRANSFER_READY=/queue/test-transfer-ready
-MQ_TRANSFER_QUEUE_TRANSFER_STATUS=/queue/test-dropbox-transfer-status
+MQ_TRANSFER_QUEUE_TRANSFER_READY=/queue/test-integration-transfer-ready
+MQ_TRANSFER_QUEUE_TRANSFER_STATUS=/queue/test-integration-transfer-status
 
 # Process MQ
 MQ_PROCESS_HOST=test_activemq
@@ -31,5 +31,5 @@ MQ_PROCESS_USER=admin
 MQ_PROCESS_PASSWORD=admin
 # False for local test environment
 MQ_PROCESS_SSL_ENABLED=False
-MQ_PROCESS_QUEUE_PROCESS_READY=/queue/test-dims-data-ready
-MQ_PROCESS_QUEUE_PROCESS_STATUS=/queue/test-drs-ingest-status
+MQ_PROCESS_QUEUE_PROCESS_READY=/queue/test-integration-dims-data-ready
+MQ_PROCESS_QUEUE_PROCESS_STATUS=/queue/test-integration-drs-ingest-status

--- a/test/unit/ingest/infrastructure/mq/publishers/test_process_ready_queue_publisher.py
+++ b/test/unit/ingest/infrastructure/mq/publishers/test_process_ready_queue_publisher.py
@@ -1,0 +1,28 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from app.ingest.infrastructure.mq.publishers.process_ready_queue_publisher import ProcessReadyQueuePublisher
+from test.resources.ingest.ingest_factory import create_ingest
+
+
+class TestProcessReadyQueuePublisher(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.TEST_INGEST = create_ingest()
+        cls.TEST_DESTINATION_PATH = "test_path"
+
+    @patch("app.common.infrastructure.mq.publishers.stomp_publisher_base.StompPublisherBase._publish_message")
+    @patch('app.ingest.infrastructure.mq.publishers.process_ready_queue_publisher.os.getenv')
+    def test_publish_message_happy_path(self, os_getenv_stub, inner_publish_message_mock) -> None:
+        os_getenv_stub.return_value = self.TEST_DESTINATION_PATH
+
+        self.sut = ProcessReadyQueuePublisher()
+        self.sut.publish_message(self.TEST_INGEST)
+
+        inner_publish_message_mock.assert_called_once_with(
+            {
+                'package_id': self.TEST_INGEST.package_id,
+                'destination_path': self.TEST_DESTINATION_PATH,
+                'application_name': self.TEST_INGEST.depositing_application.value
+            }
+        )

--- a/test/unit/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
+++ b/test/unit/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from app.ingest.infrastructure.mq.publishers.transfer_ready_queue_publisher import TransferReadyQueuePublisher
+from test.resources.ingest.ingest_factory import create_ingest
+
+
+class TestTransferReadyQueuePublisher(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.TEST_INGEST = create_ingest()
+        cls.TEST_DESTINATION_PATH = "test_path"
+
+    @patch("app.common.infrastructure.mq.publishers.stomp_publisher_base.StompPublisherBase._publish_message")
+    @patch('app.ingest.infrastructure.mq.publishers.transfer_ready_queue_publisher.os.getenv')
+    def test_publish_message_happy_path(self, os_getenv_stub, inner_publish_message_mock) -> None:
+        os_getenv_stub.return_value = self.TEST_DESTINATION_PATH
+
+        self.sut = TransferReadyQueuePublisher()
+        self.sut.publish_message(self.TEST_INGEST)
+
+        inner_publish_message_mock.assert_called_once_with(
+            {
+                'package_id': self.TEST_INGEST.package_id,
+                's3_path': self.TEST_INGEST.s3_path,
+                's3_bucket_name': self.TEST_INGEST.s3_bucket_name,
+                'destination_path': self.TEST_DESTINATION_PATH,
+                'admin_metadata': self.TEST_INGEST.admin_metadata,
+            }
+        )

--- a/test/unit/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
+++ b/test/unit/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
@@ -26,5 +26,6 @@ class TestTransferReadyQueuePublisher(TestCase):
                 's3_bucket_name': self.TEST_INGEST.s3_bucket_name,
                 'destination_path': self.TEST_DESTINATION_PATH,
                 'admin_metadata': self.TEST_INGEST.admin_metadata,
+                'application_name': self.TEST_INGEST.depositing_application.value
             }
         )


### PR DESCRIPTION
**Published messages including original_queue and retry_count fields**
* * *

**GitHub Issue**: ([link](https://app.zenhub.com/workspaces/hdc-62163f60fb08c60011fa4795/issues/harvard-lts/hdc/193))

# What does this Pull Request do?
- Includes the original_queue and retry_count fields within the headers of published messages.
- New unit tests for publishers.
- Enhanced publishers integration tests.

# How should this be tested?

A description of what steps someone could take to:
* Make sure test .env variables are updated based on .env.example files
* Rebuild test environment: docker-compose -f docker-compose-test.yml build --no-cache
* Run the local test environment: `docker-compose -f docker-compose-test.yml up`
* Execute tests: `docker exec -it test_runner pytest test`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests Yes
- integration tests Yes
- functional tests No

# Interested parties
@jessjass @ives1227 @adaybujeda

keyword: resolved