### PR TITLE
Message consumption error handling

### DIFF
--- a/activemq/activemq.Dockerfile
+++ b/activemq/activemq.Dockerfile
@@ -9,6 +9,8 @@ RUN wget ${ACTIVEMQ_DOWNLOAD_URL} \
 
 RUN mv apache-activemq-${ACTIVEMQ_VERSION} ${ACTIVEMQ_DIRECTORY}
 RUN sed -i "s|127.0.0.1|0.0.0.0|g" ${ACTIVEMQ_DIRECTORY}/conf/jetty.xml
+# Copy ActiveMQ config file with DLQ policy and redelivery plugin
+COPY ./activemq/activemq.xml ${ACTIVEMQ_DIRECTORY}/conf/activemq.xml
 
 WORKDIR ${ACTIVEMQ_DIRECTORY}/bin
 

--- a/activemq/activemq.xml
+++ b/activemq/activemq.xml
@@ -1,0 +1,150 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- START SNIPPET: example -->
+<beans
+        xmlns="http://www.springframework.org/schema/beans"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <!-- Allows us to use system properties as variables in this configuration file -->
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <value>file:${activemq.conf}/credentials.properties</value>
+        </property>
+    </bean>
+
+    <!-- Allows accessing the server log -->
+    <bean id="logQuery" class="io.fabric8.insight.log.log4j.Log4jLogQuery"
+          lazy-init="false" scope="singleton"
+          init-method="start" destroy-method="stop">
+    </bean>
+
+    <!--
+        The <broker> element is used to configure the ActiveMQ broker.
+    -->
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}"
+            schedulerSupport="true">
+        <plugins>
+            <redeliveryPlugin fallbackToDeadLetter="true"/>
+        </plugins>
+
+        <destinationPolicy>
+            <policyMap>
+                <policyEntries>
+                    <policyEntry topic=">">
+                        <!-- The constantPendingMessageLimitStrategy is used to prevent
+                             slow topic consumers to block producers and affect other consumers
+                             by limiting the number of messages that are retained
+                             For more information, see:
+
+                             http://activemq.apache.org/slow-consumer-handling.html
+
+                        -->
+                        <pendingMessageLimitStrategy>
+                            <constantPendingMessageLimitStrategy limit="1000"/>
+                        </pendingMessageLimitStrategy>
+                    </policyEntry>
+                    <policyEntry queue=">">
+                        <deadLetterStrategy>
+                            <sharedDeadLetterStrategy processNonPersistent="true"/>
+                        </deadLetterStrategy>
+                    </policyEntry>
+                </policyEntries>
+            </policyMap>
+        </destinationPolicy>
+
+
+        <!--
+            The managementContext is used to configure how ActiveMQ is exposed in
+            JMX. By default, ActiveMQ uses the MBean server that is started by
+            the JVM. For more information, see:
+
+            http://activemq.apache.org/jmx.html
+        -->
+        <managementContext>
+            <managementContext createConnector="false"/>
+        </managementContext>
+
+        <!--
+            Configure message persistence for the broker. The default persistence
+            mechanism is the KahaDB store (identified by the kahaDB tag).
+            For more information, see:
+
+            http://activemq.apache.org/persistence.html
+        -->
+        <persistenceAdapter>
+            <kahaDB directory="${activemq.data}/kahadb"/>
+        </persistenceAdapter>
+
+
+        <!--
+          The systemUsage controls the maximum amount of space the broker will
+          use before disabling caching and/or slowing down producers. For more information, see:
+          http://activemq.apache.org/producer-flow-control.html
+        -->
+        <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage percentOfJvmHeap="70"/>
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="100 gb"/>
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="50 gb"/>
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+
+        <!--
+            The transport connectors expose ActiveMQ over a given protocol to
+            clients and other brokers. For more information, see:
+
+            http://activemq.apache.org/configuring-transports.html
+        -->
+        <transportConnectors>
+            <!-- DOS protection, limit concurrent connections to 1000 and frame size to 100MB -->
+            <transportConnector name="openwire"
+                                uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="amqp"
+                                uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="stomp"
+                                uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="mqtt"
+                                uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="ws"
+                                uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+        </transportConnectors>
+
+        <!-- destroy the spring context on shutdown to stop jetty -->
+        <shutdownHooks>
+            <bean xmlns="http://www.springframework.org/schema/beans"
+                  class="org.apache.activemq.hooks.SpringContextHook"/>
+        </shutdownHooks>
+
+    </broker>
+
+    <!--
+        Enable web consoles, REST and Ajax APIs and demos
+        The web consoles requires by default login, you can disable this in the jetty.xml file
+
+        Take a look at ${ACTIVEMQ_HOME}/conf/jetty.xml for more details
+    -->
+    <import resource="jetty.xml"/>
+
+</beans>

--- a/app/common/infrastructure/mq/listeners/stomp_listener_base.py
+++ b/app/common/infrastructure/mq/listeners/stomp_listener_base.py
@@ -12,11 +12,12 @@ from app.common.infrastructure.mq.stomp_interactor import StompInteractor
 
 
 class StompListenerBase(stomp.ConnectionListener, StompInteractor, ABC):
+    __ACK_CLIENT_INDIVIDUAL = "client-individual"
 
     def __init__(self) -> None:
         super().__init__()
         self.__reconnect_on_disconnection = True
-        self.__connection = self.__create_subscribed_mq_connection()
+        self._connection = self.__create_subscribed_mq_connection()
 
     def on_message(self, frame: Frame) -> None:
         try:
@@ -25,7 +26,7 @@ class StompListenerBase(stomp.ConnectionListener, StompInteractor, ABC):
             self._logger.error(str(e))
             raise e
 
-        self._handle_received_message(message_body)
+        self._handle_received_message(message_body, frame.headers['message-id'], frame.headers['subscription'])
 
     def on_error(self, frame: Frame) -> None:
         self._logger.info("MQ error received: " + frame.body)
@@ -38,23 +39,51 @@ class StompListenerBase(stomp.ConnectionListener, StompInteractor, ABC):
 
     def reconnect(self) -> None:
         self.__reconnect_on_disconnection = True
-        self.__connection = self.__create_subscribed_mq_connection()
+        self._connection = self.__create_subscribed_mq_connection()
 
     def disconnect(self) -> None:
         self.__reconnect_on_disconnection = False
-        self.__connection.disconnect()
+        self._connection.disconnect()
 
     @abstractmethod
-    def _handle_received_message(self, message_body: dict) -> None:
+    def _handle_received_message(self, message_body: dict, message_id: str, message_subscription: str) -> None:
         """
         Handles the received message by adding child listener specific logic.
 
         :param message_body: received message body
         :type message_body: dict
+        :param message_id: received message id
+        :type message_id: str
+        :param message_subscription: received message subscription
+        :type message_subscription: str
         """
+
+    def _acknowledge_message(self, message_id: str, message_subscription: str) -> None:
+        """
+        Informs the MQ that the message was consumed
+
+        :param message_id: message id
+        :type message_id: str
+        :param message_subscription: message subscription
+        :type message_subscription: str
+        """
+        self._logger.info("Setting message with id {} as acknowledged...".format(message_id))
+        self._connection.ack(id=message_id, subscription=message_subscription)
+
+    def _unacknowledge_message(self, message_id: str, message_subscription: str) -> None:
+        """
+        Informs the MQ that the message was not consumed
+
+        :param message_id: message id
+        :type message_id: str
+        :param message_subscription: message subscription
+        :type message_subscription: str
+        """
+        self._logger.info("Setting message with id {} as unacknowledged...".format(message_id))
+        self._connection.nack(id=message_id, subscription=message_subscription)
 
     def __create_subscribed_mq_connection(self) -> stomp.Connection:
         connection = self._create_mq_connection()
-        connection.subscribe(destination=self._get_queue_name(), id=1)
+        connection.subscribe(destination=self._get_queue_name(), id=1, ack=self.__ACK_CLIENT_INDIVIDUAL)
         connection.set_listener('', self)
         return connection

--- a/app/containers.py
+++ b/app/containers.py
@@ -1,9 +1,12 @@
+import logging
+
 from dependency_injector import containers, providers
 
 from app.common.application.controllers.responses.error_response_serializer import ErrorResponseSerializer
 from app.health.application.controllers.services.git_service import GitService
 from app.health.infrastructure.compound_connectivity_service import CompoundConnectivityService
 from app.ingest.domain.services.ingest_service import IngestService
+from app.ingest.domain.services.transfer_service import TransferService
 from app.ingest.infrastructure.api.dataverse_ingest_status_api_client import DataverseIngestStatusApiClient
 from app.ingest.infrastructure.api.dataverse_params_transformer import DataverseParamsTransformer
 from app.ingest.infrastructure.data.repositories.ingest_repository import IngestRepository
@@ -32,4 +35,9 @@ class Services(containers.DeclarativeContainer):
         ingest_status_api_client=DataverseIngestStatusApiClient(
             dataverse_params_transformer=DataverseParamsTransformer()
         )
+    )
+    transfer_service = providers.Factory(
+        TransferService,
+        ingest_service=ingest_service,
+        logger=logging.getLogger()
     )

--- a/app/containers.py
+++ b/app/containers.py
@@ -6,6 +6,7 @@ from app.common.application.controllers.responses.error_response_serializer impo
 from app.health.application.controllers.services.git_service import GitService
 from app.health.infrastructure.compound_connectivity_service import CompoundConnectivityService
 from app.ingest.domain.services.ingest_service import IngestService
+from app.ingest.domain.services.process_service import ProcessService
 from app.ingest.domain.services.transfer_service import TransferService
 from app.ingest.infrastructure.api.dataverse_ingest_status_api_client import DataverseIngestStatusApiClient
 from app.ingest.infrastructure.api.dataverse_params_transformer import DataverseParamsTransformer
@@ -36,8 +37,14 @@ class Services(containers.DeclarativeContainer):
             dataverse_params_transformer=DataverseParamsTransformer()
         )
     )
+    logger = logging.getLogger()
     transfer_service = providers.Factory(
         TransferService,
         ingest_service=ingest_service,
-        logger=logging.getLogger()
+        logger=logger
+    )
+    process_service = providers.Factory(
+        ProcessService,
+        ingest_service=ingest_service,
+        logger=logger
     )

--- a/app/ingest/domain/services/exceptions/process_service_exception.py
+++ b/app/ingest/domain/services/exceptions/process_service_exception.py
@@ -1,0 +1,5 @@
+from abc import ABC
+
+
+class ProcessServiceException(Exception, ABC):
+    pass

--- a/app/ingest/domain/services/exceptions/process_status_message_handling_exception.py
+++ b/app/ingest/domain/services/exceptions/process_status_message_handling_exception.py
@@ -1,0 +1,8 @@
+from app.ingest.domain.services.exceptions.process_service_exception import ProcessServiceException
+
+
+class ProcessStatusMessageHandlingException(ProcessServiceException):
+    def __init__(self, message_id: str, reason: str) -> None:
+        self.message = f"There was an error when handling Process Status message with id {message_id}. " \
+                       f"Reason was: {reason}"
+        super().__init__(self.message)

--- a/app/ingest/domain/services/exceptions/process_status_message_missing_field_exception.py
+++ b/app/ingest/domain/services/exceptions/process_status_message_missing_field_exception.py
@@ -1,0 +1,7 @@
+from app.ingest.domain.services.exceptions.process_service_exception import ProcessServiceException
+
+
+class ProcessStatusMessageMissingFieldException(ProcessServiceException):
+    def __init__(self, message_id: str, field_name: str) -> None:
+        self.message = f"Process Status message with id {message_id} does not contain {field_name} field inside body"
+        super().__init__(self.message)

--- a/app/ingest/domain/services/exceptions/transfer_service_exception.py
+++ b/app/ingest/domain/services/exceptions/transfer_service_exception.py
@@ -1,0 +1,5 @@
+from abc import ABC
+
+
+class TransferServiceException(Exception, ABC):
+    pass

--- a/app/ingest/domain/services/exceptions/transfer_status_message_handling_exception.py
+++ b/app/ingest/domain/services/exceptions/transfer_status_message_handling_exception.py
@@ -1,0 +1,8 @@
+from app.ingest.domain.services.exceptions.transfer_service_exception import TransferServiceException
+
+
+class TransferStatusMessageHandlingException(TransferServiceException):
+    def __init__(self, message_id: str, reason: str) -> None:
+        self.message = f"There was an error when handling Transfer Status message with id {message_id}. " \
+                       f"Reason was: {reason}"
+        super().__init__(self.message)

--- a/app/ingest/domain/services/exceptions/transfer_status_message_missing_field_exception.py
+++ b/app/ingest/domain/services/exceptions/transfer_status_message_missing_field_exception.py
@@ -1,0 +1,7 @@
+from app.ingest.domain.services.exceptions.transfer_service_exception import TransferServiceException
+
+
+class TransferStatusMessageMissingFieldException(TransferServiceException):
+    def __init__(self, message_id: str, field_name: str) -> None:
+        self.message = f"Transfer Status message with id {message_id} does not contain {field_name} field inside body"
+        super().__init__(self.message)

--- a/app/ingest/domain/services/process_service.py
+++ b/app/ingest/domain/services/process_service.py
@@ -1,0 +1,55 @@
+"""
+This module defines a ProcessService, which is a domain service that defines Process operations.
+"""
+
+from logging import Logger
+
+from app.ingest.domain.services.exceptions.ingest_service_exception import IngestServiceException
+from app.ingest.domain.services.exceptions.process_status_message_handling_exception import \
+    ProcessStatusMessageHandlingException
+from app.ingest.domain.services.exceptions.process_status_message_missing_field_exception import \
+    ProcessStatusMessageMissingFieldException
+from app.ingest.domain.services.ingest_service import IngestService
+
+
+class ProcessService:
+    def __init__(
+            self,
+            ingest_service: IngestService,
+            logger: Logger
+    ) -> None:
+        self.__ingest_service = ingest_service
+        self.__logger = logger
+
+    def handle_process_status_message(self, message_body: dict, message_id: str) -> None:
+        """
+        Handles a Process Status message.
+
+        :param message_body: message body
+        :type message_body: dict
+        :param message_id: message id
+        :type message_id: str
+
+        :raises ProcessServiceException
+        """
+        try:
+            package_id = message_body['package_id']
+            process_status = message_body['batch_ingest_status']
+            drs_url = message_body['drs_url']
+        except KeyError as e:
+            raise ProcessStatusMessageMissingFieldException(message_id, str(e))
+
+        self.__logger.info("Obtaining ingest by the package id of the received message " + package_id + "...")
+        try:
+            ingest = self.__ingest_service.get_ingest_by_package_id(package_id)
+
+            if process_status == "failure":
+                self.__logger.info("Setting ingest as processed failed...")
+                self.__ingest_service.set_ingest_as_processed_failed(ingest)
+                return
+
+            self.__logger.info("Setting ingest as processed...")
+            self.__ingest_service.set_ingest_as_processed(ingest, drs_url)
+
+        except IngestServiceException as e:
+            raise ProcessStatusMessageHandlingException(message_id, str(e))

--- a/app/ingest/domain/services/transfer_service.py
+++ b/app/ingest/domain/services/transfer_service.py
@@ -3,6 +3,8 @@ from logging import Logger
 from app.ingest.domain.services.exceptions.ingest_service_exception import IngestServiceException
 from app.ingest.domain.services.exceptions.transfer_status_message_handling_exception import \
     TransferStatusMessageHandlingException
+from app.ingest.domain.services.exceptions.transfer_status_message_missing_field_exception import \
+    TransferStatusMessageMissingFieldException
 from app.ingest.domain.services.ingest_service import IngestService
 
 
@@ -24,14 +26,18 @@ class TransferService:
         :param message_id: message id
         :type message_id: str
 
-        :raises TransferStatusMessageHandlingException
+        :raises TransferServiceException
         """
         try:
             package_id = message_body['package_id']
-            self.__logger.info("Obtaining ingest by the package id of the received message {}...".format(package_id))
+            transfer_status = message_body['transfer_status']
+        except KeyError as e:
+            raise TransferStatusMessageMissingFieldException(message_id, str(e))
+
+        self.__logger.info("Obtaining ingest by the package id of the received message {}...".format(package_id))
+        try:
             ingest = self.__ingest_service.get_ingest_by_package_id(package_id)
 
-            transfer_status = message_body['transfer_status']
             if transfer_status == "failure":
                 self.__logger.info("Setting ingest as transferred failed...")
                 self.__ingest_service.set_ingest_as_transferred_failed(ingest)
@@ -43,5 +49,5 @@ class TransferService:
             self.__logger.info("Starting ingest processing...")
             self.__ingest_service.process_ingest(ingest)
 
-        except (IngestServiceException, KeyError) as e:
+        except IngestServiceException as e:
             raise TransferStatusMessageHandlingException(message_id, str(e))

--- a/app/ingest/domain/services/transfer_service.py
+++ b/app/ingest/domain/services/transfer_service.py
@@ -1,0 +1,47 @@
+from logging import Logger
+
+from app.ingest.domain.services.exceptions.ingest_service_exception import IngestServiceException
+from app.ingest.domain.services.exceptions.transfer_status_message_handling_exception import \
+    TransferStatusMessageHandlingException
+from app.ingest.domain.services.ingest_service import IngestService
+
+
+class TransferService:
+    def __init__(
+            self,
+            ingest_service: IngestService,
+            logger: Logger
+    ) -> None:
+        self.__ingest_service = ingest_service
+        self.__logger = logger
+
+    def handle_transfer_status_message(self, message_body: dict, message_id: str) -> None:
+        """
+        Handles a Transfer Status message.
+
+        :param message_body: message body
+        :type message_body: dict
+        :param message_id: message id
+        :type message_id: str
+
+        :raises TransferStatusMessageHandlingException
+        """
+        try:
+            package_id = message_body['package_id']
+            self.__logger.info("Obtaining ingest by the package id of the received message {}...".format(package_id))
+            ingest = self.__ingest_service.get_ingest_by_package_id(package_id)
+
+            transfer_status = message_body['transfer_status']
+            if transfer_status == "failure":
+                self.__logger.info("Setting ingest as transferred failed...")
+                self.__ingest_service.set_ingest_as_transferred_failed(ingest)
+                return
+
+            self.__logger.info("Setting ingest as transferred...")
+            self.__ingest_service.set_ingest_as_transferred(ingest)
+
+            self.__logger.info("Starting ingest processing...")
+            self.__ingest_service.process_ingest(ingest)
+
+        except (IngestServiceException, KeyError) as e:
+            raise TransferStatusMessageHandlingException(message_id, str(e))

--- a/app/ingest/domain/services/transfer_service.py
+++ b/app/ingest/domain/services/transfer_service.py
@@ -1,3 +1,7 @@
+"""
+This module defines a TransferService, which is a domain service that defines Transfer operations.
+"""
+
 from logging import Logger
 
 from app.ingest.domain.services.exceptions.ingest_service_exception import IngestServiceException

--- a/app/ingest/infrastructure/mq/listeners/process_status_queue_listener.py
+++ b/app/ingest/infrastructure/mq/listeners/process_status_queue_listener.py
@@ -29,10 +29,15 @@ class ProcessStatusQueueListener(StompListenerBase):
             mq_password=os.getenv('MQ_PROCESS_PASSWORD')
         )
 
-    def _handle_received_message(self, message_body: dict) -> None:
-        self._logger.info("Received message from Process Queue. Message body: " + str(message_body))
-        package_id = message_body['package_id']
+    def _handle_received_message(self, message_body: dict, message_id: str, message_subscription: str) -> None:
+        self._logger.info(
+            "Received message from Process Queue. Message body: {}. Message id: {}".format(
+                str(message_body),
+                message_id
+            )
+        )
         try:
+            package_id = message_body['package_id']
             self._logger.info("Obtaining ingest by the package id of the received message " + package_id + "...")
             ingest = self.__ingest_service.get_ingest_by_package_id(package_id)
 
@@ -40,11 +45,14 @@ class ProcessStatusQueueListener(StompListenerBase):
             if transfer_status == "failure":
                 self._logger.info("Setting ingest as processed failed...")
                 self.__ingest_service.set_ingest_as_processed_failed(ingest)
+                self._acknowledge_message(message_id, message_subscription)
                 return
 
             self._logger.info("Setting ingest as processed...")
             self.__ingest_service.set_ingest_as_processed(ingest, message_body["drs_url"])
 
-        except IngestServiceException as e:
+            self._acknowledge_message(message_id, message_subscription)
+
+        except (IngestServiceException, KeyError) as e:
             self._logger.error(str(e))
-            raise e
+            self._unacknowledge_message(message_id, message_subscription)

--- a/app/ingest/infrastructure/mq/listeners/transfer_status_queue_listener.py
+++ b/app/ingest/infrastructure/mq/listeners/transfer_status_queue_listener.py
@@ -7,8 +7,7 @@ import os
 from app.common.infrastructure.mq.listeners.stomp_listener_base import StompListenerBase
 from app.common.infrastructure.mq.mq_connection_params import MqConnectionParams
 from app.containers import Services
-from app.ingest.domain.services.exceptions.transfer_status_message_handling_exception import \
-    TransferStatusMessageHandlingException
+from app.ingest.domain.services.exceptions.transfer_service_exception import TransferServiceException
 from app.ingest.domain.services.transfer_service import TransferService
 
 
@@ -40,6 +39,6 @@ class TransferStatusQueueListener(StompListenerBase):
         try:
             self.__transfer_service.handle_transfer_status_message(message_body, message_id)
             self._acknowledge_message(message_id, message_subscription)
-        except TransferStatusMessageHandlingException as e:
+        except TransferServiceException as e:
             self._logger.error(str(e))
             self._unacknowledge_message(message_id, message_subscription)

--- a/test/unit/ingest/domain/services/test_process_service.py
+++ b/test/unit/ingest/domain/services/test_process_service.py
@@ -1,0 +1,148 @@
+from logging import Logger
+from unittest import TestCase
+from unittest.mock import Mock
+
+from app.ingest.domain.services.exceptions.get_ingest_by_package_id_exception import GetIngestByPackageIdException
+from app.ingest.domain.services.exceptions.process_status_message_handling_exception import \
+    ProcessStatusMessageHandlingException
+from app.ingest.domain.services.exceptions.process_status_message_missing_field_exception import \
+    ProcessStatusMessageMissingFieldException
+from app.ingest.domain.services.exceptions.set_ingest_as_processed_exception import SetIngestAsProcessedException
+from app.ingest.domain.services.exceptions.set_ingest_as_processed_failed_exception import \
+    SetIngestAsProcessedFailedException
+from app.ingest.domain.services.ingest_service import IngestService
+from app.ingest.domain.services.process_service import ProcessService
+from test.resources.ingest.ingest_factory import create_ingest
+
+
+class TestProcessService(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.TEST_INGEST = create_ingest()
+        cls.TEST_PACKAGE_ID = cls.TEST_INGEST.package_id
+
+        cls.TEST_PROCESS_STATUS_MESSAGE_SUCCESSFUL = {
+            "package_id": cls.TEST_INGEST.package_id,
+            "application_name": cls.TEST_INGEST.depositing_application,
+            "batch_ingest_status": "successful",
+            "drs_url": "test",
+            "message": "test"
+        }
+
+        cls.TEST_PROCESS_STATUS_MESSAGE_FAILURE = {
+            "package_id": cls.TEST_INGEST.package_id,
+            "application_name": cls.TEST_INGEST.depositing_application,
+            "batch_ingest_status": "failure",
+            "drs_url": "test",
+            "message": "test"
+        }
+
+        cls.TEST_PROCESS_MESSAGE_MISSING_FIELD = {
+            "application_name": cls.TEST_INGEST.depositing_application
+        }
+
+        cls.TEST_MESSAGE_ID = "test"
+
+    def setUp(self) -> None:
+        self.logger_mock = Mock(spec=Logger)
+
+    def test_handle_process_status_message_successful_happy_path(self) -> None:
+        ingest_service_stub = Mock(spec=IngestService)
+        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
+
+        sut = ProcessService(ingest_service_stub, self.logger_mock)
+        sut.handle_process_status_message(
+            self.TEST_PROCESS_STATUS_MESSAGE_SUCCESSFUL,
+            self.TEST_MESSAGE_ID
+        )
+
+        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with("test_package_id")
+        ingest_service_stub.set_ingest_as_processed.assert_called_once_with(
+            self.TEST_INGEST,
+            self.TEST_PROCESS_STATUS_MESSAGE_SUCCESSFUL["drs_url"]
+        )
+
+    def test_handle_process_status_message_successful_service_raises_get_ingest_by_package_id_exception(self) -> None:
+        ingest_service_stub = Mock(spec=IngestService)
+        ingest_service_stub.get_ingest_by_package_id.side_effect = GetIngestByPackageIdException("test", "test")
+
+        sut = ProcessService(ingest_service_stub, self.logger_mock)
+        with self.assertRaises(ProcessStatusMessageHandlingException):
+            sut.handle_process_status_message(
+                self.TEST_PROCESS_STATUS_MESSAGE_SUCCESSFUL,
+                self.TEST_MESSAGE_ID
+            )
+
+        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
+        ingest_service_stub.set_ingest_as_processed_failed.assert_not_called()
+        ingest_service_stub.set_ingest_as_processed.assert_not_called()
+
+    def test_handle_process_status_message_successful_service_raises_set_ingest_as_processed_exception(self) -> None:
+        ingest_service_stub = Mock(spec=IngestService)
+        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
+        ingest_service_stub.set_ingest_as_processed.side_effect = SetIngestAsProcessedException("test", "test")
+
+        sut = ProcessService(ingest_service_stub, self.logger_mock)
+        with self.assertRaises(ProcessStatusMessageHandlingException):
+            sut.handle_process_status_message(
+                self.TEST_PROCESS_STATUS_MESSAGE_SUCCESSFUL,
+                self.TEST_MESSAGE_ID
+            )
+
+        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
+        ingest_service_stub.set_ingest_as_processed_failed.assert_not_called()
+        ingest_service_stub.set_ingest_as_processed.assert_called_once_with(
+            self.TEST_INGEST,
+            self.TEST_PROCESS_STATUS_MESSAGE_SUCCESSFUL["drs_url"]
+        )
+
+    def test_handle_process_status_message_failure_happy_path(self) -> None:
+        ingest_service_stub = Mock(spec=IngestService)
+        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
+
+        sut = ProcessService(ingest_service_stub, self.logger_mock)
+        sut.handle_process_status_message(
+            self.TEST_PROCESS_STATUS_MESSAGE_FAILURE,
+            self.TEST_MESSAGE_ID
+        )
+
+        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
+        ingest_service_stub.set_ingest_as_processed_failed.assert_called_once_with(self.TEST_INGEST)
+        ingest_service_stub.set_ingest_as_processed.assert_not_called()
+
+    def test_handle_process_status_message_failure_service_raises_set_ingest_as_processed_failed_exception(
+            self
+    ) -> None:
+        ingest_service_stub = Mock(spec=IngestService)
+        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
+        ingest_service_stub.set_ingest_as_processed_failed.side_effect = SetIngestAsProcessedFailedException(
+            "test",
+            "test"
+        )
+
+        sut = ProcessService(ingest_service_stub, self.logger_mock)
+        with self.assertRaises(ProcessStatusMessageHandlingException):
+            sut.handle_process_status_message(
+                self.TEST_PROCESS_STATUS_MESSAGE_FAILURE,
+                self.TEST_MESSAGE_ID
+            )
+
+        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
+        ingest_service_stub.set_ingest_as_processed_failed.assert_called_once_with(self.TEST_INGEST)
+        ingest_service_stub.set_ingest_as_processed.assert_not_called()
+
+    def test_handle_process_status_message_missing_message_field(self) -> None:
+        ingest_service_mock = Mock(spec=IngestService)
+        ingest_service_mock.get_ingest_by_package_id.return_value = self.TEST_INGEST
+
+        sut = ProcessService(ingest_service_mock, self.logger_mock)
+        with self.assertRaises(ProcessStatusMessageMissingFieldException):
+            sut.handle_process_status_message(
+                self.TEST_PROCESS_MESSAGE_MISSING_FIELD,
+                self.TEST_MESSAGE_ID
+            )
+
+        ingest_service_mock.get_ingest_by_package_id.assert_not_called()
+        ingest_service_mock.set_ingest_as_transferred_failed.assert_not_called()
+        ingest_service_mock.set_ingest_as_transferred.assert_not_called()
+        ingest_service_mock.process_ingest.assert_not_called()

--- a/test/unit/ingest/domain/services/test_transfer_service.py
+++ b/test/unit/ingest/domain/services/test_transfer_service.py
@@ -1,0 +1,143 @@
+from logging import Logger
+from unittest import TestCase
+from unittest.mock import Mock
+
+from app.ingest.domain.services.exceptions.get_ingest_by_package_id_exception import GetIngestByPackageIdException
+from app.ingest.domain.services.exceptions.process_ingest_exception import ProcessIngestException
+from app.ingest.domain.services.exceptions.set_ingest_as_transferred_exception import SetIngestAsTransferredException
+from app.ingest.domain.services.exceptions.set_ingest_as_transferred_failed_exception import \
+    SetIngestAsTransferredFailedException
+from app.ingest.domain.services.exceptions.transfer_status_message_handling_exception import \
+    TransferStatusMessageHandlingException
+from app.ingest.domain.services.ingest_service import IngestService
+from app.ingest.domain.services.transfer_service import TransferService
+from test.resources.ingest.ingest_factory import create_ingest
+
+
+class TestTransferService(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.TEST_INGEST = create_ingest()
+        cls.TEST_PACKAGE_ID = cls.TEST_INGEST.package_id
+
+        cls.TEST_TRANSFER_STATUS_MESSAGE_SUCCESSFUL = {
+            "package_id": cls.TEST_PACKAGE_ID,
+            "transfer_status": "successful"
+        }
+
+        cls.TEST_TRANSFER_STATUS_MESSAGE_FAILURE = {
+            "package_id": cls.TEST_PACKAGE_ID,
+            "transfer_status": "failure"
+        }
+
+        cls.TEST_MESSAGE_ID = "test"
+
+    def setUp(self) -> None:
+        self.logger_mock = Mock(spec=Logger)
+
+    def test_handle_transfer_status_message_successful_happy_path(self) -> None:
+        ingest_service_stub = Mock(spec=IngestService)
+        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
+
+        sut = TransferService(ingest_service_stub, self.logger_mock)
+        sut.handle_transfer_status_message(
+            self.TEST_TRANSFER_STATUS_MESSAGE_SUCCESSFUL,
+            self.TEST_MESSAGE_ID
+        )
+
+        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
+        ingest_service_stub.set_ingest_as_transferred_failed.assert_not_called()
+        ingest_service_stub.set_ingest_as_transferred.assert_called_once_with(self.TEST_INGEST)
+        ingest_service_stub.process_ingest.assert_called_once_with(self.TEST_INGEST)
+
+    def test_handle_transfer_status_message_successful_ingest_service_raises_get_ingest_by_package_id_exception(
+            self
+    ) -> None:
+        ingest_service_stub = Mock(spec=IngestService)
+        ingest_service_stub.get_ingest_by_package_id.side_effect = GetIngestByPackageIdException("test", "test")
+
+        sut = TransferService(ingest_service_stub, self.logger_mock)
+        with self.assertRaises(TransferStatusMessageHandlingException):
+            sut.handle_transfer_status_message(
+                self.TEST_TRANSFER_STATUS_MESSAGE_SUCCESSFUL,
+                self.TEST_MESSAGE_ID
+            )
+
+        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
+        ingest_service_stub.set_ingest_as_transferred_failed.assert_not_called()
+        ingest_service_stub.set_ingest_as_transferred.assert_not_called()
+        ingest_service_stub.process_ingest.assert_not_called()
+
+    def test_handle_transfer_status_message_successful_service_raises_set_ingest_as_transferred_exception(self) -> None:
+        ingest_service_stub = Mock(spec=IngestService)
+        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
+        ingest_service_stub.set_ingest_as_transferred.side_effect = SetIngestAsTransferredException(
+            "test",
+            "test"
+        )
+
+        sut = TransferService(ingest_service_stub, self.logger_mock)
+        with self.assertRaises(TransferStatusMessageHandlingException):
+            sut.handle_transfer_status_message(
+                self.TEST_TRANSFER_STATUS_MESSAGE_SUCCESSFUL,
+                self.TEST_MESSAGE_ID
+            )
+
+        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
+        ingest_service_stub.set_ingest_as_transferred_failed.assert_not_called()
+        ingest_service_stub.set_ingest_as_transferred.assert_called_once_with(self.TEST_INGEST)
+        ingest_service_stub.process_ingest.assert_not_called()
+
+    def test_handle_transfer_status_message_successful_service_raises_process_ingest_exception(self) -> None:
+        ingest_service_stub = Mock(spec=IngestService)
+        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
+        ingest_service_stub.process_ingest.side_effect = ProcessIngestException("test", "test")
+
+        sut = TransferService(ingest_service_stub, self.logger_mock)
+        with self.assertRaises(TransferStatusMessageHandlingException):
+            sut.handle_transfer_status_message(
+                self.TEST_TRANSFER_STATUS_MESSAGE_SUCCESSFUL,
+                self.TEST_MESSAGE_ID
+            )
+
+        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
+        ingest_service_stub.set_ingest_as_transferred_failed.assert_not_called()
+        ingest_service_stub.set_ingest_as_transferred.assert_called_once_with(self.TEST_INGEST)
+        ingest_service_stub.process_ingest.assert_called_once_with(self.TEST_INGEST)
+
+    def test_handle_transfer_status_message_failure_happy_path(self) -> None:
+        ingest_service_stub = Mock(spec=IngestService)
+        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
+
+        sut = TransferService(ingest_service_stub, self.logger_mock)
+        sut.handle_transfer_status_message(
+            self.TEST_TRANSFER_STATUS_MESSAGE_FAILURE,
+            self.TEST_MESSAGE_ID
+        )
+
+        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
+        ingest_service_stub.set_ingest_as_transferred_failed.assert_called_once_with(self.TEST_INGEST)
+        ingest_service_stub.set_ingest_as_transferred.assert_not_called()
+        ingest_service_stub.process_ingest.assert_not_called()
+
+    def test_handle_transfer_status_message_failure_service_raises_set_ingest_as_transferred_failed_exception(
+            self
+    ) -> None:
+        ingest_service_stub = Mock(spec=IngestService)
+        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
+        ingest_service_stub.set_ingest_as_transferred_failed.side_effect = SetIngestAsTransferredFailedException(
+            "test",
+            "test"
+        )
+
+        sut = TransferService(ingest_service_stub, self.logger_mock)
+        with self.assertRaises(TransferStatusMessageHandlingException):
+            sut.handle_transfer_status_message(
+                self.TEST_TRANSFER_STATUS_MESSAGE_FAILURE,
+                self.TEST_MESSAGE_ID
+            )
+
+        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
+        ingest_service_stub.set_ingest_as_transferred_failed.assert_called_once_with(self.TEST_INGEST)
+        ingest_service_stub.set_ingest_as_transferred.assert_not_called()
+        ingest_service_stub.process_ingest.assert_not_called()

--- a/test/unit/ingest/domain/services/test_transfer_service.py
+++ b/test/unit/ingest/domain/services/test_transfer_service.py
@@ -9,6 +9,8 @@ from app.ingest.domain.services.exceptions.set_ingest_as_transferred_failed_exce
     SetIngestAsTransferredFailedException
 from app.ingest.domain.services.exceptions.transfer_status_message_handling_exception import \
     TransferStatusMessageHandlingException
+from app.ingest.domain.services.exceptions.transfer_status_message_missing_field_exception import \
+    TransferStatusMessageMissingFieldException
 from app.ingest.domain.services.ingest_service import IngestService
 from app.ingest.domain.services.transfer_service import TransferService
 from test.resources.ingest.ingest_factory import create_ingest
@@ -28,6 +30,10 @@ class TestTransferService(TestCase):
         cls.TEST_TRANSFER_STATUS_MESSAGE_FAILURE = {
             "package_id": cls.TEST_PACKAGE_ID,
             "transfer_status": "failure"
+        }
+
+        cls.TEST_TRANSFER_MESSAGE_MISSING_FIELD = {
+            "package_id": cls.TEST_PACKAGE_ID
         }
 
         cls.TEST_MESSAGE_ID = "test"
@@ -141,3 +147,19 @@ class TestTransferService(TestCase):
         ingest_service_stub.set_ingest_as_transferred_failed.assert_called_once_with(self.TEST_INGEST)
         ingest_service_stub.set_ingest_as_transferred.assert_not_called()
         ingest_service_stub.process_ingest.assert_not_called()
+
+    def test_handle_transfer_status_message_missing_message_field(self) -> None:
+        ingest_service_mock = Mock(spec=IngestService)
+        ingest_service_mock.get_ingest_by_package_id.return_value = self.TEST_INGEST
+
+        sut = TransferService(ingest_service_mock, self.logger_mock)
+        with self.assertRaises(TransferStatusMessageMissingFieldException):
+            sut.handle_transfer_status_message(
+                self.TEST_TRANSFER_MESSAGE_MISSING_FIELD,
+                self.TEST_MESSAGE_ID
+            )
+
+        ingest_service_mock.get_ingest_by_package_id.assert_not_called()
+        ingest_service_mock.set_ingest_as_transferred_failed.assert_not_called()
+        ingest_service_mock.set_ingest_as_transferred.assert_not_called()
+        ingest_service_mock.process_ingest.assert_not_called()

--- a/test/unit/ingest/infrastructure/mq/listeners/test_process_status_queue_listener.py
+++ b/test/unit/ingest/infrastructure/mq/listeners/test_process_status_queue_listener.py
@@ -3,11 +3,8 @@ from unittest.mock import patch, Mock
 
 from stomp import Connection
 
-from app.ingest.domain.services.exceptions.get_ingest_by_package_id_exception import GetIngestByPackageIdException
-from app.ingest.domain.services.exceptions.set_ingest_as_processed_exception import SetIngestAsProcessedException
-from app.ingest.domain.services.exceptions.set_ingest_as_processed_failed_exception import \
-    SetIngestAsProcessedFailedException
-from app.ingest.domain.services.ingest_service import IngestService
+from app.ingest.domain.services.exceptions.process_service_exception import ProcessServiceException
+from app.ingest.domain.services.process_service import ProcessService
 from app.ingest.infrastructure.mq.listeners.process_status_queue_listener import ProcessStatusQueueListener
 from test.resources.ingest.ingest_factory import create_ingest
 
@@ -22,18 +19,11 @@ class TestProcessStatusQueueListener(TestCase):
         cls.TEST_INGEST = create_ingest()
         cls.TEST_PACKAGE_ID = cls.TEST_INGEST.package_id
 
-        cls.TEST_PROCESS_STATUS_RECEIVED_MESSAGE_SUCCESSFUL = {
+        cls.TEST_PROCESS_STATUS_MESSAGE = {
             "package_id": cls.TEST_INGEST.package_id,
             "application_name": cls.TEST_INGEST.depositing_application,
             "batch_ingest_status": "successful",
             "drs_url": "test",
-            "message": "test"
-        }
-
-        cls.TEST_PROCESS_STATUS_RECEIVED_MESSAGE_FAILURE = {
-            "package_id": cls.TEST_INGEST.package_id,
-            "application_name": cls.TEST_INGEST.depositing_application,
-            "batch_ingest_status": "failure",
             "message": "test"
         }
 
@@ -46,20 +36,18 @@ class TestProcessStatusQueueListener(TestCase):
 
     def test_handle_received_message_successful_happy_path(self, create_subscribed_mq_connection_mock) -> None:
         create_subscribed_mq_connection_mock.return_value = self.connection_mock
-        ingest_service_stub = Mock(spec=IngestService)
-        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
+        process_service_mock = Mock(spec=ProcessService)
 
-        sut = ProcessStatusQueueListener(ingest_service_stub)
+        sut = ProcessStatusQueueListener(process_service_mock)
         sut._handle_received_message(
-            self.TEST_PROCESS_STATUS_RECEIVED_MESSAGE_SUCCESSFUL,
+            self.TEST_PROCESS_STATUS_MESSAGE,
             self.TEST_MESSAGE_ID,
             self.TEST_MESSAGE_SUBSCRIPTION
         )
 
-        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with("test_package_id")
-        ingest_service_stub.set_ingest_as_processed.assert_called_once_with(
-            self.TEST_INGEST,
-            self.TEST_PROCESS_STATUS_RECEIVED_MESSAGE_SUCCESSFUL["drs_url"]
+        process_service_mock.handle_process_status_message.assert_called_once_with(
+            self.TEST_PROCESS_STATUS_MESSAGE,
+            self.TEST_MESSAGE_ID
         )
         self.connection_mock.ack.assert_called_once_with(
             id=self.TEST_MESSAGE_ID,
@@ -67,104 +55,18 @@ class TestProcessStatusQueueListener(TestCase):
         )
         self.connection_mock.nack.assert_not_called()
 
-    def test_handle_received_message_successful_service_raises_get_ingest_by_package_id_exception(
-            self,
-            create_subscribed_mq_connection_mock
-    ) -> None:
+    def test_handle_received_message_service_raises_exception(self, create_subscribed_mq_connection_mock) -> None:
         create_subscribed_mq_connection_mock.return_value = self.connection_mock
-        ingest_service_stub = Mock(spec=IngestService)
-        ingest_service_stub.get_ingest_by_package_id.side_effect = GetIngestByPackageIdException("test", "test")
+        process_service_stub = Mock(spec=ProcessService)
+        process_service_stub.handle_process_status_message.side_effect = ProcessServiceException()
 
-        sut = ProcessStatusQueueListener(ingest_service_stub)
+        sut = ProcessStatusQueueListener(process_service_stub)
         sut._handle_received_message(
-            self.TEST_PROCESS_STATUS_RECEIVED_MESSAGE_SUCCESSFUL,
+            self.TEST_PROCESS_STATUS_MESSAGE,
             self.TEST_MESSAGE_ID,
             self.TEST_MESSAGE_SUBSCRIPTION
         )
 
-        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
-        ingest_service_stub.set_ingest_as_processed_failed.assert_not_called()
-        ingest_service_stub.set_ingest_as_processed.assert_not_called()
-        self.connection_mock.ack.assert_not_called()
-        self.connection_mock.nack.assert_called_once_with(
-            id=self.TEST_MESSAGE_ID,
-            subscription=self.TEST_MESSAGE_SUBSCRIPTION
-        )
-
-    def test_handle_received_message_successful_service_raises_set_ingest_as_processed_exception(
-            self,
-            create_subscribed_mq_connection_mock
-    ) -> None:
-        create_subscribed_mq_connection_mock.return_value = self.connection_mock
-        ingest_service_stub = Mock(spec=IngestService)
-        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
-        ingest_service_stub.set_ingest_as_processed.side_effect = SetIngestAsProcessedException(
-            "test",
-            "test"
-        )
-
-        sut = ProcessStatusQueueListener(ingest_service_stub)
-        sut._handle_received_message(
-            self.TEST_PROCESS_STATUS_RECEIVED_MESSAGE_SUCCESSFUL,
-            self.TEST_MESSAGE_ID,
-            self.TEST_MESSAGE_SUBSCRIPTION
-        )
-
-        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
-        ingest_service_stub.set_ingest_as_processed_failed.assert_not_called()
-        ingest_service_stub.set_ingest_as_processed.assert_called_once_with(
-            self.TEST_INGEST,
-            self.TEST_PROCESS_STATUS_RECEIVED_MESSAGE_SUCCESSFUL["drs_url"]
-        )
-        self.connection_mock.ack.assert_not_called()
-        self.connection_mock.nack.assert_called_once_with(
-            id=self.TEST_MESSAGE_ID,
-            subscription=self.TEST_MESSAGE_SUBSCRIPTION
-        )
-
-    def test_handle_received_message_failure_happy_path(self, create_subscribed_mq_connection_mock) -> None:
-        create_subscribed_mq_connection_mock.return_value = self.connection_mock
-        ingest_service_stub = Mock(spec=IngestService)
-        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
-
-        sut = ProcessStatusQueueListener(ingest_service_stub)
-        sut._handle_received_message(
-            self.TEST_PROCESS_STATUS_RECEIVED_MESSAGE_FAILURE,
-            self.TEST_MESSAGE_ID,
-            self.TEST_MESSAGE_SUBSCRIPTION
-        )
-
-        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
-        ingest_service_stub.set_ingest_as_processed_failed.assert_called_once_with(self.TEST_INGEST)
-        ingest_service_stub.set_ingest_as_processed.assert_not_called()
-        self.connection_mock.ack.assert_called_once_with(
-            id=self.TEST_MESSAGE_ID,
-            subscription=self.TEST_MESSAGE_SUBSCRIPTION
-        )
-        self.connection_mock.nack.assert_not_called()
-
-    def test_handle_received_message_failure_service_raises_set_ingest_as_processed_failed_exception(
-            self,
-            create_subscribed_mq_connection_mock
-    ) -> None:
-        create_subscribed_mq_connection_mock.return_value = self.connection_mock
-        ingest_service_stub = Mock(spec=IngestService)
-        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
-        ingest_service_stub.set_ingest_as_processed_failed.side_effect = SetIngestAsProcessedFailedException(
-            "test",
-            "test"
-        )
-
-        sut = ProcessStatusQueueListener(ingest_service_stub)
-        sut._handle_received_message(
-            self.TEST_PROCESS_STATUS_RECEIVED_MESSAGE_FAILURE,
-            self.TEST_MESSAGE_ID,
-            self.TEST_MESSAGE_SUBSCRIPTION
-        )
-
-        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
-        ingest_service_stub.set_ingest_as_processed_failed.assert_called_once_with(self.TEST_INGEST)
-        ingest_service_stub.set_ingest_as_processed.assert_not_called()
         self.connection_mock.ack.assert_not_called()
         self.connection_mock.nack.assert_called_once_with(
             id=self.TEST_MESSAGE_ID,

--- a/test/unit/ingest/infrastructure/mq/listeners/test_transfer_status_queue_listener.py
+++ b/test/unit/ingest/infrastructure/mq/listeners/test_transfer_status_queue_listener.py
@@ -3,12 +3,9 @@ from unittest.mock import patch, Mock
 
 from stomp import Connection
 
-from app.ingest.domain.services.exceptions.get_ingest_by_package_id_exception import GetIngestByPackageIdException
-from app.ingest.domain.services.exceptions.process_ingest_exception import ProcessIngestException
-from app.ingest.domain.services.exceptions.set_ingest_as_transferred_exception import SetIngestAsTransferredException
-from app.ingest.domain.services.exceptions.set_ingest_as_transferred_failed_exception import \
-    SetIngestAsTransferredFailedException
-from app.ingest.domain.services.ingest_service import IngestService
+from app.ingest.domain.services.exceptions.transfer_status_message_handling_exception import \
+    TransferStatusMessageHandlingException
+from app.ingest.domain.services.transfer_service import TransferService
 from app.ingest.infrastructure.mq.listeners.transfer_status_queue_listener import TransferStatusQueueListener
 from test.resources.ingest.ingest_factory import create_ingest
 
@@ -23,7 +20,7 @@ class TestTransferStatusQueueListener(TestCase):
         cls.TEST_INGEST = create_ingest()
         cls.TEST_PACKAGE_ID = cls.TEST_INGEST.package_id
 
-        cls.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_SUCCESSFUL = {
+        cls.TEST_TRANSFER_STATUS_MESSAGE = {
             "package_id": cls.TEST_PACKAGE_ID,
             "transfer_status": "successful"
         }
@@ -42,151 +39,43 @@ class TestTransferStatusQueueListener(TestCase):
 
     def test_handle_received_message_successful_happy_path(self, create_subscribed_mq_connection_mock) -> None:
         create_subscribed_mq_connection_mock.return_value = self.connection_mock
-        ingest_service_stub = Mock(spec=IngestService)
-        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
+        transfer_service_mock = Mock(spec=TransferService)
 
-        sut = TransferStatusQueueListener(ingest_service_stub)
+        sut = TransferStatusQueueListener(transfer_service_mock)
         sut._handle_received_message(
-            self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_SUCCESSFUL,
+            self.TEST_TRANSFER_STATUS_MESSAGE,
             self.TEST_MESSAGE_ID,
             self.TEST_MESSAGE_SUBSCRIPTION
         )
 
-        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
-        ingest_service_stub.set_ingest_as_transferred_failed.assert_not_called()
-        ingest_service_stub.set_ingest_as_transferred.assert_called_once_with(self.TEST_INGEST)
-        ingest_service_stub.process_ingest.assert_called_once_with(self.TEST_INGEST)
+        transfer_service_mock.handle_transfer_status_message.assert_called_once_with(
+            self.TEST_TRANSFER_STATUS_MESSAGE,
+            self.TEST_MESSAGE_ID
+        )
         self.connection_mock.ack.assert_called_once_with(
             id=self.TEST_MESSAGE_ID,
             subscription=self.TEST_MESSAGE_SUBSCRIPTION
         )
         self.connection_mock.nack.assert_not_called()
 
-    def test_handle_received_message_successful_service_raises_get_ingest_by_package_id_exception(
+    def test_handle_received_message_service_raises_transfer_status_message_handling_exception(
             self,
             create_subscribed_mq_connection_mock
     ) -> None:
         create_subscribed_mq_connection_mock.return_value = self.connection_mock
-        ingest_service_stub = Mock(spec=IngestService)
-        ingest_service_stub.get_ingest_by_package_id.side_effect = GetIngestByPackageIdException("test", "test")
-
-        sut = TransferStatusQueueListener(ingest_service_stub)
-        sut._handle_received_message(
-            self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_SUCCESSFUL,
-            self.TEST_MESSAGE_ID,
-            self.TEST_MESSAGE_SUBSCRIPTION
-        )
-
-        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
-        ingest_service_stub.set_ingest_as_transferred_failed.assert_not_called()
-        ingest_service_stub.set_ingest_as_transferred.assert_not_called()
-        ingest_service_stub.process_ingest.assert_not_called()
-        self.connection_mock.ack.assert_not_called()
-        self.connection_mock.nack.assert_called_once_with(
-            id=self.TEST_MESSAGE_ID,
-            subscription=self.TEST_MESSAGE_SUBSCRIPTION
-        )
-
-    def test_handle_received_message_successful_service_raises_set_ingest_as_transferred_exception(
-            self,
-            create_subscribed_mq_connection_mock
-    ) -> None:
-        create_subscribed_mq_connection_mock.return_value = self.connection_mock
-        ingest_service_stub = Mock(spec=IngestService)
-        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
-        ingest_service_stub.set_ingest_as_transferred.side_effect = SetIngestAsTransferredException(
+        transfer_service_stub = Mock(spec=TransferService)
+        transfer_service_stub.handle_transfer_status_message.side_effect = TransferStatusMessageHandlingException(
             "test",
             "test"
         )
 
-        sut = TransferStatusQueueListener(ingest_service_stub)
+        sut = TransferStatusQueueListener(transfer_service_stub)
         sut._handle_received_message(
-            self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_SUCCESSFUL,
+            self.TEST_TRANSFER_STATUS_MESSAGE,
             self.TEST_MESSAGE_ID,
             self.TEST_MESSAGE_SUBSCRIPTION
         )
 
-        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
-        ingest_service_stub.set_ingest_as_transferred_failed.assert_not_called()
-        ingest_service_stub.set_ingest_as_transferred.assert_called_once_with(self.TEST_INGEST)
-        ingest_service_stub.process_ingest.assert_not_called()
-        self.connection_mock.ack.assert_not_called()
-        self.connection_mock.nack.assert_called_once_with(
-            id=self.TEST_MESSAGE_ID,
-            subscription=self.TEST_MESSAGE_SUBSCRIPTION
-        )
-
-    def test_handle_received_message_successful_service_raises_process_ingest_exception(
-            self,
-            create_subscribed_mq_connection_mock
-    ) -> None:
-        create_subscribed_mq_connection_mock.return_value = self.connection_mock
-        ingest_service_stub = Mock(spec=IngestService)
-        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
-        ingest_service_stub.process_ingest.side_effect = ProcessIngestException("test", "test")
-
-        sut = TransferStatusQueueListener(ingest_service_stub)
-        sut._handle_received_message(
-            self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_SUCCESSFUL,
-            self.TEST_MESSAGE_ID,
-            self.TEST_MESSAGE_SUBSCRIPTION
-        )
-
-        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
-        ingest_service_stub.set_ingest_as_transferred_failed.assert_not_called()
-        ingest_service_stub.set_ingest_as_transferred.assert_called_once_with(self.TEST_INGEST)
-        ingest_service_stub.process_ingest.assert_called_once_with(self.TEST_INGEST)
-        self.connection_mock.ack.assert_not_called()
-        self.connection_mock.nack.assert_called_once_with(
-            id=self.TEST_MESSAGE_ID,
-            subscription=self.TEST_MESSAGE_SUBSCRIPTION
-        )
-
-    def test_handle_received_message_failure_happy_path(self, create_subscribed_mq_connection_mock) -> None:
-        create_subscribed_mq_connection_mock.return_value = self.connection_mock
-        ingest_service_stub = Mock(spec=IngestService)
-        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
-
-        sut = TransferStatusQueueListener(ingest_service_stub)
-        sut._handle_received_message(
-            self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_FAILURE,
-            self.TEST_MESSAGE_ID,
-            self.TEST_MESSAGE_SUBSCRIPTION
-        )
-
-        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
-        ingest_service_stub.set_ingest_as_transferred_failed.assert_called_once_with(self.TEST_INGEST)
-        ingest_service_stub.set_ingest_as_transferred.assert_not_called()
-        ingest_service_stub.process_ingest.assert_not_called()
-        self.connection_mock.ack.assert_called_once_with(
-            id=self.TEST_MESSAGE_ID,
-            subscription=self.TEST_MESSAGE_SUBSCRIPTION
-        )
-        self.connection_mock.nack.assert_not_called()
-
-    def test_handle_received_message_failure_service_raises_set_ingest_as_transferred_failed_exception(
-            self,
-            create_subscribed_mq_connection_mock
-    ) -> None:
-        create_subscribed_mq_connection_mock.return_value = self.connection_mock
-        ingest_service_stub = Mock(spec=IngestService)
-        ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
-        ingest_service_stub.set_ingest_as_transferred_failed.side_effect = SetIngestAsTransferredFailedException(
-            "test",
-            "test"
-        )
-
-        sut = TransferStatusQueueListener(ingest_service_stub)
-        sut._handle_received_message(
-            self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_FAILURE,
-            self.TEST_MESSAGE_ID,
-            self.TEST_MESSAGE_SUBSCRIPTION
-        )
-
-        ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
-        ingest_service_stub.set_ingest_as_transferred_failed.assert_called_once_with(self.TEST_INGEST)
-        ingest_service_stub.set_ingest_as_transferred.assert_not_called()
-        ingest_service_stub.process_ingest.assert_not_called()
         self.connection_mock.ack.assert_not_called()
         self.connection_mock.nack.assert_called_once_with(
             id=self.TEST_MESSAGE_ID,

--- a/test/unit/ingest/infrastructure/mq/listeners/test_transfer_status_queue_listener.py
+++ b/test/unit/ingest/infrastructure/mq/listeners/test_transfer_status_queue_listener.py
@@ -24,11 +24,6 @@ class TestTransferStatusQueueListener(TestCase):
             "transfer_status": "successful"
         }
 
-        cls.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_FAILURE = {
-            "package_id": cls.TEST_PACKAGE_ID,
-            "transfer_status": "failure"
-        }
-
         cls.TEST_MESSAGE_ID = "test"
 
         cls.TEST_MESSAGE_SUBSCRIPTION = "test"

--- a/test/unit/ingest/infrastructure/mq/listeners/test_transfer_status_queue_listener.py
+++ b/test/unit/ingest/infrastructure/mq/listeners/test_transfer_status_queue_listener.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 from unittest.mock import patch, Mock
 
+from stomp import Connection
+
 from app.ingest.domain.services.exceptions.get_ingest_by_package_id_exception import GetIngestByPackageIdException
 from app.ingest.domain.services.exceptions.process_ingest_exception import ProcessIngestException
 from app.ingest.domain.services.exceptions.set_ingest_as_transferred_exception import SetIngestAsTransferredException
@@ -31,38 +33,65 @@ class TestTransferStatusQueueListener(TestCase):
             "transfer_status": "failure"
         }
 
+        cls.TEST_MESSAGE_ID = "test"
+
+        cls.TEST_MESSAGE_SUBSCRIPTION = "test"
+
+    def setUp(self) -> None:
+        self.connection_mock = Mock(spec=Connection)
+
     def test_handle_received_message_successful_happy_path(self, create_subscribed_mq_connection_mock) -> None:
+        create_subscribed_mq_connection_mock.return_value = self.connection_mock
         ingest_service_stub = Mock(spec=IngestService)
         ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
 
-        self.sut = TransferStatusQueueListener(ingest_service_stub)
-        self.sut._handle_received_message(self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_SUCCESSFUL)
+        sut = TransferStatusQueueListener(ingest_service_stub)
+        sut._handle_received_message(
+            self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_SUCCESSFUL,
+            self.TEST_MESSAGE_ID,
+            self.TEST_MESSAGE_SUBSCRIPTION
+        )
 
         ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
         ingest_service_stub.set_ingest_as_transferred_failed.assert_not_called()
         ingest_service_stub.set_ingest_as_transferred.assert_called_once_with(self.TEST_INGEST)
         ingest_service_stub.process_ingest.assert_called_once_with(self.TEST_INGEST)
+        self.connection_mock.ack.assert_called_once_with(
+            id=self.TEST_MESSAGE_ID,
+            subscription=self.TEST_MESSAGE_SUBSCRIPTION
+        )
+        self.connection_mock.nack.assert_not_called()
 
     def test_handle_received_message_successful_service_raises_get_ingest_by_package_id_exception(
             self,
             create_subscribed_mq_connection_mock
     ) -> None:
+        create_subscribed_mq_connection_mock.return_value = self.connection_mock
         ingest_service_stub = Mock(spec=IngestService)
         ingest_service_stub.get_ingest_by_package_id.side_effect = GetIngestByPackageIdException("test", "test")
 
-        self.sut = TransferStatusQueueListener(ingest_service_stub)
-        with self.assertRaises(GetIngestByPackageIdException):
-            self.sut._handle_received_message(self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_SUCCESSFUL)
+        sut = TransferStatusQueueListener(ingest_service_stub)
+        sut._handle_received_message(
+            self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_SUCCESSFUL,
+            self.TEST_MESSAGE_ID,
+            self.TEST_MESSAGE_SUBSCRIPTION
+        )
 
         ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
         ingest_service_stub.set_ingest_as_transferred_failed.assert_not_called()
         ingest_service_stub.set_ingest_as_transferred.assert_not_called()
         ingest_service_stub.process_ingest.assert_not_called()
+        self.connection_mock.ack.assert_not_called()
+        self.connection_mock.nack.assert_called_once_with(
+            id=self.TEST_MESSAGE_ID,
+            subscription=self.TEST_MESSAGE_SUBSCRIPTION
+        )
 
     def test_handle_received_message_successful_service_raises_set_ingest_as_transferred_exception(
             self,
             create_subscribed_mq_connection_mock
     ) -> None:
+        create_subscribed_mq_connection_mock.return_value = self.connection_mock
         ingest_service_stub = Mock(spec=IngestService)
         ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
         ingest_service_stub.set_ingest_as_transferred.side_effect = SetIngestAsTransferredException(
@@ -70,48 +99,76 @@ class TestTransferStatusQueueListener(TestCase):
             "test"
         )
 
-        self.sut = TransferStatusQueueListener(ingest_service_stub)
-        with self.assertRaises(SetIngestAsTransferredException):
-            self.sut._handle_received_message(self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_SUCCESSFUL)
+        sut = TransferStatusQueueListener(ingest_service_stub)
+        sut._handle_received_message(
+            self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_SUCCESSFUL,
+            self.TEST_MESSAGE_ID,
+            self.TEST_MESSAGE_SUBSCRIPTION
+        )
 
         ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
         ingest_service_stub.set_ingest_as_transferred_failed.assert_not_called()
         ingest_service_stub.set_ingest_as_transferred.assert_called_once_with(self.TEST_INGEST)
         ingest_service_stub.process_ingest.assert_not_called()
+        self.connection_mock.ack.assert_not_called()
+        self.connection_mock.nack.assert_called_once_with(
+            id=self.TEST_MESSAGE_ID,
+            subscription=self.TEST_MESSAGE_SUBSCRIPTION
+        )
 
     def test_handle_received_message_successful_service_raises_process_ingest_exception(
             self,
             create_subscribed_mq_connection_mock
     ) -> None:
+        create_subscribed_mq_connection_mock.return_value = self.connection_mock
         ingest_service_stub = Mock(spec=IngestService)
         ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
         ingest_service_stub.process_ingest.side_effect = ProcessIngestException("test", "test")
 
-        self.sut = TransferStatusQueueListener(ingest_service_stub)
-        with self.assertRaises(ProcessIngestException):
-            self.sut._handle_received_message(self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_SUCCESSFUL)
+        sut = TransferStatusQueueListener(ingest_service_stub)
+        sut._handle_received_message(
+            self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_SUCCESSFUL,
+            self.TEST_MESSAGE_ID,
+            self.TEST_MESSAGE_SUBSCRIPTION
+        )
 
         ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
         ingest_service_stub.set_ingest_as_transferred_failed.assert_not_called()
         ingest_service_stub.set_ingest_as_transferred.assert_called_once_with(self.TEST_INGEST)
         ingest_service_stub.process_ingest.assert_called_once_with(self.TEST_INGEST)
+        self.connection_mock.ack.assert_not_called()
+        self.connection_mock.nack.assert_called_once_with(
+            id=self.TEST_MESSAGE_ID,
+            subscription=self.TEST_MESSAGE_SUBSCRIPTION
+        )
 
     def test_handle_received_message_failure_happy_path(self, create_subscribed_mq_connection_mock) -> None:
+        create_subscribed_mq_connection_mock.return_value = self.connection_mock
         ingest_service_stub = Mock(spec=IngestService)
         ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
 
-        self.sut = TransferStatusQueueListener(ingest_service_stub)
-        self.sut._handle_received_message(self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_FAILURE)
+        sut = TransferStatusQueueListener(ingest_service_stub)
+        sut._handle_received_message(
+            self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_FAILURE,
+            self.TEST_MESSAGE_ID,
+            self.TEST_MESSAGE_SUBSCRIPTION
+        )
 
         ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
         ingest_service_stub.set_ingest_as_transferred_failed.assert_called_once_with(self.TEST_INGEST)
         ingest_service_stub.set_ingest_as_transferred.assert_not_called()
         ingest_service_stub.process_ingest.assert_not_called()
+        self.connection_mock.ack.assert_called_once_with(
+            id=self.TEST_MESSAGE_ID,
+            subscription=self.TEST_MESSAGE_SUBSCRIPTION
+        )
+        self.connection_mock.nack.assert_not_called()
 
     def test_handle_received_message_failure_service_raises_set_ingest_as_transferred_failed_exception(
             self,
             create_subscribed_mq_connection_mock
     ) -> None:
+        create_subscribed_mq_connection_mock.return_value = self.connection_mock
         ingest_service_stub = Mock(spec=IngestService)
         ingest_service_stub.get_ingest_by_package_id.return_value = self.TEST_INGEST
         ingest_service_stub.set_ingest_as_transferred_failed.side_effect = SetIngestAsTransferredFailedException(
@@ -119,11 +176,19 @@ class TestTransferStatusQueueListener(TestCase):
             "test"
         )
 
-        self.sut = TransferStatusQueueListener(ingest_service_stub)
-        with self.assertRaises(SetIngestAsTransferredFailedException):
-            self.sut._handle_received_message(self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_FAILURE)
+        sut = TransferStatusQueueListener(ingest_service_stub)
+        sut._handle_received_message(
+            self.TEST_TRANSFER_STATUS_RECEIVED_MESSAGE_FAILURE,
+            self.TEST_MESSAGE_ID,
+            self.TEST_MESSAGE_SUBSCRIPTION
+        )
 
         ingest_service_stub.get_ingest_by_package_id.assert_called_once_with(self.TEST_PACKAGE_ID)
         ingest_service_stub.set_ingest_as_transferred_failed.assert_called_once_with(self.TEST_INGEST)
         ingest_service_stub.set_ingest_as_transferred.assert_not_called()
         ingest_service_stub.process_ingest.assert_not_called()
+        self.connection_mock.ack.assert_not_called()
+        self.connection_mock.nack.assert_called_once_with(
+            id=self.TEST_MESSAGE_ID,
+            subscription=self.TEST_MESSAGE_SUBSCRIPTION
+        )

--- a/test/unit/ingest/infrastructure/mq/listeners/test_transfer_status_queue_listener.py
+++ b/test/unit/ingest/infrastructure/mq/listeners/test_transfer_status_queue_listener.py
@@ -3,8 +3,7 @@ from unittest.mock import patch, Mock
 
 from stomp import Connection
 
-from app.ingest.domain.services.exceptions.transfer_status_message_handling_exception import \
-    TransferStatusMessageHandlingException
+from app.ingest.domain.services.exceptions.transfer_service_exception import TransferServiceException
 from app.ingest.domain.services.transfer_service import TransferService
 from app.ingest.infrastructure.mq.listeners.transfer_status_queue_listener import TransferStatusQueueListener
 from test.resources.ingest.ingest_factory import create_ingest
@@ -58,16 +57,10 @@ class TestTransferStatusQueueListener(TestCase):
         )
         self.connection_mock.nack.assert_not_called()
 
-    def test_handle_received_message_service_raises_transfer_status_message_handling_exception(
-            self,
-            create_subscribed_mq_connection_mock
-    ) -> None:
+    def test_handle_received_message_service_raises_exception(self, create_subscribed_mq_connection_mock) -> None:
         create_subscribed_mq_connection_mock.return_value = self.connection_mock
         transfer_service_stub = Mock(spec=TransferService)
-        transfer_service_stub.handle_transfer_status_message.side_effect = TransferStatusMessageHandlingException(
-            "test",
-            "test"
-        )
+        transfer_service_stub.handle_transfer_status_message.side_effect = TransferServiceException()
 
         sut = TransferStatusQueueListener(transfer_service_stub)
         sut._handle_received_message(


### PR DESCRIPTION
**Message consumption error handling**
* * *

**GitHub Issue**: ([link](https://app.zenhub.com/workspaces/hdc-62163f60fb08c60011fa4795/issues/harvard-lts/hdc/192))

Other Relevant Links:
* [ActiveMQ docs - Message Redelivery and DLQ Handling](https://activemq.apache.org/message-redelivery-and-dlq-handling)
* [AmazonMQ docs - Elements and Their Attributes Permitted in Amazon MQ Configurations](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/permitted-attributes.html) - It is required for the correct operation of error handling that, as included in the activemq.xml configuration for the dockerized ActiveMQs for local dev environment, AmazonMQ includes the necessary configurations for DLQ policy and the redelivery plugin with fallback to DLQ.

# What does this Pull Request do?
It adds the management of errors in the consumption of messages in the application's listeners, managing through ACKs and NACKs (client-individual configuration) the successful or unsuccessful consumption of messages and sending to DLQ the unsuccessful ones.

A general refactor for listeners is also included, which extracts misplaced business logic from listeners to domain services.

Error handling in reading messages due to non-existent fields has also been reinforced, to avoid uncaught exceptions and send these messages to DLQ for further review.

# How should this be tested?

A description of what steps someone could take to:

* Make sure test .env variables are updated based on .env.example file
* Rebuild test environment: docker-compose -f docker-compose-test.yml build --no-cache
* Run the local test environment: `docker-compose -f docker-compose-test.yml up`
* Execute tests: `docker exec -it test_runner pytest test`

For a manual functional test:

* Make sure .env variables are updated based on .env.example file
* Rebuild dev environment: docker-compose -f docker-compose-dev.yml build --no-cache
* Run the local dev environment: `docker-compose -f docker-compose-dev.yml up`
* Send a malformed message to one of the queues (e.g. drs-ingest-status) :

![malformed_drs_ingest_status_message](https://user-images.githubusercontent.com/17010447/170450396-5dc57489-dfa7-4d22-9f31-ee8bbd91debc.png)

This should cause message consumption to fail due to missing required params.

* Wait until message is consumed and check that it is sent to DLQ:

![malformed_drs_ingest_status_queues](https://user-images.githubusercontent.com/17010447/170450743-3ea7545c-df44-48bf-9dc5-a364a6d9b8c6.png)

The message must be readable by accessing the DLQ:

![malformed_drs_ingest_status_dlq](https://user-images.githubusercontent.com/17010447/170450974-cfa8d7a7-a66e-4caa-8039-5be300f46526.png)

* dims.log file should contain entries like the following related with the unsuccessful message consumption:


```
Received frame: 'MESSAGE', len(body)=15

Received message from Process Queue. Message body: {'test': 'test'}. Message id: ID:9a426ce536c2-38897-1653553765765-8:1:1:1:1

Process Status message with id ID:9a426ce536c2-38897-1653553765765-8:1:1:1:1 does not contain 'package_id' field inside body

Setting message with id ID:9a426ce536c2-38897-1653553765765-8:1:1:1:1 as unacknowledged...

Sending frame: 'NACK'
```

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests Yes
- integration tests Yes

# Interested parties
@jessjass @ives1227 @adaybujeda 

Keyword: resolved
