### PR TITLE
Reinforcing malformed messages error handling (None field values)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
       # Checks-out repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v2
 
-      # Set up Python 3.10.2 environment
-      - name: Set up Python 3.10.4
+      # Set up Python 3.9.13 environment
+      - name: Set up Python 3.9.13
         uses: actions/setup-python@v1
         with:
-          python-version: "3.10.4"
+          python-version: "3.9.13"
 
       # Install dependencies
       - name: Install dependencies

--- a/app/ingest/domain/services/exceptions/message_body_field_exception.py
+++ b/app/ingest/domain/services/exceptions/message_body_field_exception.py
@@ -1,0 +1,5 @@
+from abc import ABC
+
+
+class MessageBodyFieldException(Exception, ABC):
+    pass

--- a/app/ingest/domain/services/exceptions/message_body_missing_field_exception.py
+++ b/app/ingest/domain/services/exceptions/message_body_missing_field_exception.py
@@ -1,0 +1,7 @@
+from app.ingest.domain.services.exceptions.message_body_field_exception import MessageBodyFieldException
+
+
+class MessageBodyMissingFieldException(MessageBodyFieldException):
+    def __init__(self, message_id: str, field_name: str) -> None:
+        self.message = f"Message with id {message_id} does not contain {field_name} field inside body"
+        super().__init__(self.message)

--- a/app/ingest/domain/services/exceptions/message_body_none_field_exception.py
+++ b/app/ingest/domain/services/exceptions/message_body_none_field_exception.py
@@ -1,0 +1,7 @@
+from app.ingest.domain.services.exceptions.message_body_field_exception import MessageBodyFieldException
+
+
+class MessageBodyNoneFieldException(MessageBodyFieldException):
+    def __init__(self, message_id: str, field_name: str) -> None:
+        self.message = f"Message with id {message_id} has None value for field {field_name} inside body"
+        super().__init__(self.message)

--- a/app/ingest/domain/services/exceptions/process_status_message_missing_field_exception.py
+++ b/app/ingest/domain/services/exceptions/process_status_message_missing_field_exception.py
@@ -1,7 +1,0 @@
-from app.ingest.domain.services.exceptions.process_service_exception import ProcessServiceException
-
-
-class ProcessStatusMessageMissingFieldException(ProcessServiceException):
-    def __init__(self, message_id: str, field_name: str) -> None:
-        self.message = f"Process Status message with id {message_id} does not contain {field_name} field inside body"
-        super().__init__(self.message)

--- a/app/ingest/domain/services/exceptions/transfer_status_message_missing_field_exception.py
+++ b/app/ingest/domain/services/exceptions/transfer_status_message_missing_field_exception.py
@@ -1,7 +1,0 @@
-from app.ingest.domain.services.exceptions.transfer_service_exception import TransferServiceException
-
-
-class TransferStatusMessageMissingFieldException(TransferServiceException):
-    def __init__(self, message_id: str, field_name: str) -> None:
-        self.message = f"Transfer Status message with id {message_id} does not contain {field_name} field inside body"
-        super().__init__(self.message)

--- a/app/ingest/domain/services/message_body_transformer.py
+++ b/app/ingest/domain/services/message_body_transformer.py
@@ -1,6 +1,5 @@
 from app.ingest.domain.services.exceptions.message_body_missing_field_exception import MessageBodyMissingFieldException
-from app.ingest.domain.services.exceptions.message_body_none_field_exception import \
-    MessageBodyNoneFieldException
+from app.ingest.domain.services.exceptions.message_body_none_field_exception import MessageBodyNoneFieldException
 
 
 class MessageBodyTransformer:

--- a/app/ingest/domain/services/message_body_transformer.py
+++ b/app/ingest/domain/services/message_body_transformer.py
@@ -1,0 +1,17 @@
+from app.ingest.domain.services.exceptions.message_body_missing_field_exception import MessageBodyMissingFieldException
+from app.ingest.domain.services.exceptions.message_body_none_field_exception import \
+    MessageBodyNoneFieldException
+
+
+class MessageBodyTransformer:
+
+    def get_message_body_field_value(self, field_name: str, message_body: dict, message_id: str) -> str:
+        try:
+            field_value = message_body[field_name]
+        except KeyError as e:
+            raise MessageBodyMissingFieldException(message_id, str(e))
+
+        if field_value is None:
+            raise MessageBodyNoneFieldException(message_id, field_name)
+
+        return field_value

--- a/app/ingest/domain/services/process_service.py
+++ b/app/ingest/domain/services/process_service.py
@@ -5,11 +5,11 @@ This module defines a ProcessService, which is a domain service that defines Pro
 from logging import Logger
 
 from app.ingest.domain.services.exceptions.ingest_service_exception import IngestServiceException
+from app.ingest.domain.services.exceptions.message_body_field_exception import MessageBodyFieldException
 from app.ingest.domain.services.exceptions.process_status_message_handling_exception import \
     ProcessStatusMessageHandlingException
-from app.ingest.domain.services.exceptions.process_status_message_missing_field_exception import \
-    ProcessStatusMessageMissingFieldException
 from app.ingest.domain.services.ingest_service import IngestService
+from app.ingest.domain.services.message_body_transformer import MessageBodyTransformer
 
 
 class ProcessService:
@@ -32,12 +32,21 @@ class ProcessService:
 
         :raises ProcessServiceException
         """
+        message_body_transformer = MessageBodyTransformer()
         try:
-            package_id = message_body['package_id']
-            process_status = message_body['batch_ingest_status']
-            drs_url = message_body['drs_url']
-        except KeyError as e:
-            raise ProcessStatusMessageMissingFieldException(message_id, str(e))
+            package_id = message_body_transformer.get_message_body_field_value(
+                'package_id',
+                message_body,
+                message_id
+            )
+            process_status = message_body_transformer.get_message_body_field_value(
+                'batch_ingest_status',
+                message_body,
+                message_id
+            )
+            drs_url = message_body_transformer.get_message_body_field_value('drs_url', message_body, message_id)
+        except MessageBodyFieldException as e:
+            raise ProcessStatusMessageHandlingException(message_id, str(e))
 
         self.__logger.info("Obtaining ingest by the package id of the received message " + package_id + "...")
         try:

--- a/app/ingest/domain/services/process_service.py
+++ b/app/ingest/domain/services/process_service.py
@@ -44,12 +44,8 @@ class ProcessService:
                 message_body,
                 message_id
             )
-            drs_url = message_body_transformer.get_message_body_field_value('drs_url', message_body, message_id)
-        except MessageBodyFieldException as e:
-            raise ProcessStatusMessageHandlingException(message_id, str(e))
 
-        self.__logger.info("Obtaining ingest by the package id of the received message " + package_id + "...")
-        try:
+            self.__logger.info("Obtaining ingest by the package id of the received message " + package_id + "...")
             ingest = self.__ingest_service.get_ingest_by_package_id(package_id)
 
             if process_status == "failure":
@@ -58,7 +54,8 @@ class ProcessService:
                 return
 
             self.__logger.info("Setting ingest as processed...")
+            drs_url = message_body_transformer.get_message_body_field_value('drs_url', message_body, message_id)
             self.__ingest_service.set_ingest_as_processed(ingest, drs_url)
 
-        except IngestServiceException as e:
+        except (MessageBodyFieldException, IngestServiceException) as e:
             raise ProcessStatusMessageHandlingException(message_id, str(e))

--- a/app/ingest/domain/services/transfer_service.py
+++ b/app/ingest/domain/services/transfer_service.py
@@ -5,11 +5,11 @@ This module defines a TransferService, which is a domain service that defines Tr
 from logging import Logger
 
 from app.ingest.domain.services.exceptions.ingest_service_exception import IngestServiceException
+from app.ingest.domain.services.exceptions.message_body_field_exception import MessageBodyFieldException
 from app.ingest.domain.services.exceptions.transfer_status_message_handling_exception import \
     TransferStatusMessageHandlingException
-from app.ingest.domain.services.exceptions.transfer_status_message_missing_field_exception import \
-    TransferStatusMessageMissingFieldException
 from app.ingest.domain.services.ingest_service import IngestService
+from app.ingest.domain.services.message_body_transformer import MessageBodyTransformer
 
 
 class TransferService:
@@ -32,11 +32,20 @@ class TransferService:
 
         :raises TransferServiceException
         """
+        message_body_transformer = MessageBodyTransformer()
         try:
-            package_id = message_body['package_id']
-            transfer_status = message_body['transfer_status']
-        except KeyError as e:
-            raise TransferStatusMessageMissingFieldException(message_id, str(e))
+            package_id = message_body_transformer.get_message_body_field_value(
+                'package_id',
+                message_body,
+                message_id
+            )
+            transfer_status = message_body_transformer.get_message_body_field_value(
+                'transfer_status',
+                message_body,
+                message_id
+            )
+        except MessageBodyFieldException as e:
+            raise TransferStatusMessageHandlingException(message_id, str(e))
 
         self.__logger.info("Obtaining ingest by the package id of the received message {}...".format(package_id))
         try:

--- a/test/unit/ingest/domain/services/test_transfer_service.py
+++ b/test/unit/ingest/domain/services/test_transfer_service.py
@@ -153,7 +153,6 @@ class TestTransferService(TestCase):
 
     def test_handle_transfer_status_message_missing_message_field(self) -> None:
         ingest_service_mock = Mock(spec=IngestService)
-        ingest_service_mock.get_ingest_by_package_id.return_value = self.TEST_INGEST
 
         sut = TransferService(ingest_service_mock, self.logger_mock)
         with self.assertRaises(TransferStatusMessageHandlingException):
@@ -169,7 +168,6 @@ class TestTransferService(TestCase):
 
     def test_handle_transfer_status_message_none_message_field(self) -> None:
         ingest_service_mock = Mock(spec=IngestService)
-        ingest_service_mock.get_ingest_by_package_id.return_value = self.TEST_INGEST
 
         sut = TransferService(ingest_service_mock, self.logger_mock)
         with self.assertRaises(TransferStatusMessageHandlingException):


### PR DESCRIPTION
**Reinforcing malformed messages error handling (None field values)**
* * *

# What does this Pull Request do?
Reinforces malformed messages error handling. In particular by checking for None values in the message body fields.

# How should this be tested?

* Make sure test .env variables are updated based on .env.example file
* Rebuild test environment: docker-compose -f docker-compose-test.yml build --no-cache
* Run the local test environment: `docker-compose -f docker-compose-test.yml up`
* Execute tests: `docker exec -it test_runner pytest test`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests Yes
- integration tests n/a
- functional tests n/a

# Interested parties
@jessjass
