### PR TITLE
Fix destination path for different applications 

### DIFF
--- a/app/ingest/infrastructure/api/dataverse_ingest_status_api_client.py
+++ b/app/ingest/infrastructure/api/dataverse_ingest_status_api_client.py
@@ -18,7 +18,7 @@ from app.ingest.infrastructure.api.exceptions.transform_package_id_exception imp
 
 
 class DataverseIngestStatusApiClient(IIngestStatusApiClient):
-    __API_ENDPOINT = "/api/datasets/submitDatasetVersionToArchive/:persistentId/{version}/status?persistentId=doi:{doi}"
+    __API_ENDPOINT = "/api/datasets/:persistentId/{version}/archivalStatus?persistentId=doi:{doi}"
     __API_REQUEST_MAX_RETRIES = 2
 
     def __init__(self, dataverse_params_transformer: DataverseParamsTransformer) -> None:

--- a/app/ingest/infrastructure/mq/publishers/process_ready_queue_publisher.py
+++ b/app/ingest/infrastructure/mq/publishers/process_ready_queue_publisher.py
@@ -4,6 +4,7 @@ which includes the necessary logic to connect to the remote MQ and publish a pro
 """
 
 import os
+import os.path
 
 from app.common.infrastructure.mq.mq_connection_params import MqConnectionParams
 from app.common.infrastructure.mq.publishers.stomp_publisher_base import StompPublisherBase
@@ -31,9 +32,18 @@ class ProcessReadyQueuePublisher(IProcessReadyQueuePublisher, StompPublisherBase
         )
 
     def __create_process_ready_message(self, ingest: Ingest) -> dict:
+        # Set destination path based on application
+        base_dropbox_path = os.getenv('BASE_DROPBOX_PATH')
+        destination_path = ""
+
+        if ingest.depositing_application == "Dataverse":
+            destination_path = os.path.join(base_dropbox_path, os.getenv('DATAVERSE_DROPBOX_NAME'), "incoming")
+        elif ingest.depositing_application == "ePADD":
+            destination_path = os.path.join(base_dropbox_path, os.getenv('EPADD_DROPBOX_NAME'), "incoming")
+
         return {
             'package_id': ingest.package_id,
-            'destination_path': os.getenv('INGEST_DESTINATION_PATH'),
+            'destination_path': destination_path,
             'admin_metadata': ingest.admin_metadata,
             'application_name': ingest.depositing_application
         }

--- a/app/ingest/infrastructure/mq/publishers/transfer_ready_queue_publisher.py
+++ b/app/ingest/infrastructure/mq/publishers/transfer_ready_queue_publisher.py
@@ -31,10 +31,19 @@ class TransferReadyQueuePublisher(ITransferReadyQueuePublisher, StompPublisherBa
         )
 
     def __create_transfer_ready_message(self, ingest: Ingest) -> dict:
+        # Set destination path based on application
+        base_dropbox_path = os.getenv('BASE_DROPBOX_PATH')
+        destination_path = ""
+
+        if ingest.depositing_application == "Dataverse":
+            destination_path = os.path.join(base_dropbox_path, os.getenv('DATAVERSE_DROPBOX_NAME'), "incoming")
+        elif ingest.depositing_application == "ePADD":
+            destination_path = os.path.join(base_dropbox_path, os.getenv('EPADD_DROPBOX_NAME'), "incoming")
+
         return {
             'package_id': ingest.package_id,
             's3_path': ingest.s3_path,
             's3_bucket_name': ingest.s3_bucket_name,
-            'destination_path': os.getenv('INGEST_DESTINATION_PATH'),
+            'destination_path': destination_path,
             'application_name': ingest.depositing_application
         }

--- a/env.example
+++ b/env.example
@@ -3,8 +3,12 @@ DIMS_ENVIRONMENT=development
 LOG_FILE_PATH=/home/dimsuser/logs/dims.log
 # Choose from CRITICAL, ERROR, WARNING, INFO, DEBUG
 LOG_LEVEL=DEBUG
-INGEST_DESTINATION_PATH=/some/path/dtsdev/incoming
 GIT_PYTHON_REFRESH=quiet
+
+# Dropboxes
+BASE_DROPBOX_PATH=/home/appuser/dropbox
+DATAVERSE_DROPBOX_NAME=dvndev
+EPADD_DROPBOX_NAME=epadddev_secure
 
 # MongoDB
 MONGODB_HOST_1=dev_mongodb

--- a/test/integration/ingest/infrastructure/api/test_dataverse_ingest_status_api_client.py
+++ b/test/integration/ingest/infrastructure/api/test_dataverse_ingest_status_api_client.py
@@ -21,7 +21,7 @@ class TestDataverseIngestStatusApiClient(IntegrationTestBase):
         cls.API_DATASET_CREATE_ENDPOINT = "/api/dataverses/{collection_alias}/datasets"
         cls.API_DATASET_PUBLISH_ENDPOINT = "/api/datasets/:persistentId/actions/:publish?persistentId={persistent_id}&type=major&assureIsIndexed=true"
         cls.API_DATASET_DELETE_ENDPOINT = "/api/datasets/{dataset_id}/destroy"
-        cls.API_DATASET_STATUS_ENDPOINT = "/api/datasets/submitDatasetVersionToArchive/{dataset_id}/{version}/status"
+        cls.API_DATASET_STATUS_ENDPOINT = "/api/datasets/{dataset_id}/{version}/archivalStatus"
 
         cls.TEST_DATAVERSE_ALIAS = "test_dataverse_alias"
 

--- a/test/integration/ingest/infrastructure/mq/publishers/test_process_ready_queue_publisher.py
+++ b/test/integration/ingest/infrastructure/mq/publishers/test_process_ready_queue_publisher.py
@@ -34,9 +34,11 @@ class TestProcessReadyQueuePublisher(StompPublisherIntegrationTestBase):
         return os.getenv('MQ_PROCESS_QUEUE_PROCESS_READY')
 
     def _get_expected_body(self) -> dict:
+        base_dropbox_path = os.getenv('BASE_DROPBOX_PATH')
+
         return {
             'package_id': self.TEST_INGEST.package_id,
-            'destination_path': os.getenv('INGEST_DESTINATION_PATH'),
+            'destination_path': os.path.join(base_dropbox_path, os.getenv('DATAVERSE_DROPBOX_NAME'), "incoming"),
             'application_name': self.TEST_INGEST.depositing_application,
             'admin_metadata':
                 self.TEST_INGEST.admin_metadata | {'original_queue': self._get_queue_name(), 'retry_count': 0}

--- a/test/integration/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
+++ b/test/integration/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
@@ -34,11 +34,13 @@ class TestTransferReadyQueuePublisher(StompPublisherIntegrationTestBase):
         return os.getenv('MQ_TRANSFER_QUEUE_TRANSFER_READY')
 
     def _get_expected_body(self) -> dict:
+        base_dropbox_path = os.getenv('BASE_DROPBOX_PATH')
+
         return {
             'package_id': self.TEST_INGEST.package_id,
             's3_path': self.TEST_INGEST.s3_path,
             's3_bucket_name': self.TEST_INGEST.s3_bucket_name,
-            'destination_path': os.getenv('INGEST_DESTINATION_PATH'),
+            'destination_path': os.path.join(base_dropbox_path, os.getenv('DATAVERSE_DROPBOX_NAME'), "incoming"),
             'admin_metadata': {
                 'original_queue': self._get_queue_name(),
                 'retry_count': 0

--- a/test/integration/test.env.example
+++ b/test/integration/test.env.example
@@ -1,5 +1,9 @@
 # Application
-INGEST_DESTINATION_PATH=/some/path/dtsdev/incoming
+
+# Dropboxes
+BASE_DROPBOX_PATH=/some/path/dropbox
+DATAVERSE_DROPBOX_NAME=dvndev
+EPADD_DROPBOX_NAME=epadddev_secure
 
 # MongoDB
 MONGODB_HOST_1=test_mongodb

--- a/test/unit/ingest/infrastructure/mq/publishers/test_process_ready_queue_publisher.py
+++ b/test/unit/ingest/infrastructure/mq/publishers/test_process_ready_queue_publisher.py
@@ -22,7 +22,7 @@ class TestProcessReadyQueuePublisher(TestCase):
         inner_publish_message_mock.assert_called_once_with(
             {
                 'package_id': self.TEST_INGEST.package_id,
-                'destination_path': self.TEST_DESTINATION_PATH,
+                'destination_path': self.TEST_DESTINATION_PATH + "/" + self.TEST_DESTINATION_PATH + "/incoming",
                 'admin_metadata': self.TEST_INGEST.admin_metadata,
                 'application_name': self.TEST_INGEST.depositing_application
             }

--- a/test/unit/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
+++ b/test/unit/ingest/infrastructure/mq/publishers/test_transfer_ready_queue_publisher.py
@@ -24,7 +24,7 @@ class TestTransferReadyQueuePublisher(TestCase):
                 'package_id': self.TEST_INGEST.package_id,
                 's3_path': self.TEST_INGEST.s3_path,
                 's3_bucket_name': self.TEST_INGEST.s3_bucket_name,
-                'destination_path': self.TEST_DESTINATION_PATH,
+                'destination_path': self.TEST_DESTINATION_PATH + "/" + self.TEST_DESTINATION_PATH + "/incoming",
                 'application_name': self.TEST_INGEST.depositing_application
             }
         )


### PR DESCRIPTION
**Fix destination path for different applications**
* * *

**GitHub Issue**: N/A - fix end-to-end run

# What does this Pull Request do?
This PR updates code so DIMS can set the appropriate `destination_path` for a given application calling ingest

# How should this be tested?

1. `docker-compose -f docker-compose-test.yml up`
2. `docker exec -it test_runner pytest test/integration`

**NOTE: 1 integration test will fail due to the Dataverse status call update. This integration test needs to be fixed in another PR. The error will read `Not Found for url: http://dvn-dev-hdc.lib.harvard.edu/api/datasets/submitDatasetVersionToArchive/:persistentId/1.0/status?persistentId=doi:10.5072/FK2/HRYKY9`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n/a
- integration tests? Yes

# Interested parties
@ives1227 
