### PR TITLE
Update status call for multiple application use

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
       # Checks-out repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v2
 
-      # Set up Python 3.9.14 environment
-      - name: Set up Python 3.9.14
+      # Set up Python 3.9.15 environment
+      - name: Set up Python 3.9.15
         uses: actions/setup-python@v1
         with:
-          python-version: "3.9.14"
+          python-version: "3.9.15"
 
       # Install dependencies
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
       # Checks-out repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v2
 
-      # Set up Python 3.9.15 environment
-      - name: Set up Python 3.9.15
+      # Set up Python 3.9.16 environment
+      - name: Set up Python 3.9.16
         uses: actions/setup-python@v1
         with:
-          python-version: "3.9.15"
+          python-version: "3.9.16"
 
       # Install dependencies
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
       # Checks-out repository under $GITHUB_WORKSPACE
       - uses: actions/checkout@v2
 
-      # Set up Python 3.9.13 environment
-      - name: Set up Python 3.9.13
+      # Set up Python 3.9.14 environment
+      - name: Set up Python 3.9.14
         uses: actions/setup-python@v1
         with:
-          python-version: "3.9.13"
+          python-version: "3.9.14"
 
       # Install dependencies
       - name: Install dependencies

--- a/app/ingest/application/controllers/ingest_post_controller.py
+++ b/app/ingest/application/controllers/ingest_post_controller.py
@@ -31,6 +31,11 @@ class IngestPostController:
         admin_metadata: dict = request.json.get("admin_metadata")
         depositing_application: str = request.json.get("depositing_application")
 
+        if "dry_run" in request.json:
+            dry_run: str = request.json.get("dry_run")
+        else:
+            dry_run = None
+
         new_ingest = Ingest(
             package_id=package_id,
             s3_path=s3_path,
@@ -38,7 +43,8 @@ class IngestPostController:
             admin_metadata=admin_metadata,
             status=IngestStatus.pending_transfer_to_dropbox,
             depositing_application=depositing_application,
-            drs_url=None
+            drs_url=None,
+            dry_run=dry_run
         )
 
         try:

--- a/app/ingest/domain/models/ingest/ingest.py
+++ b/app/ingest/domain/models/ingest/ingest.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from app.ingest.domain.models.ingest.ingest_status import IngestStatus
@@ -13,3 +13,4 @@ class Ingest:
     status: IngestStatus
     depositing_application: str
     drs_url: Optional[str]
+    dry_run: Optional[str] = field(default=None)

--- a/app/ingest/domain/services/ingest_service.py
+++ b/app/ingest/domain/services/ingest_service.py
@@ -94,7 +94,8 @@ class IngestService:
         ingest.status = IngestStatus.transferred_to_dropbox_successful
         try:
             self.__ingest_repository.save(ingest)
-            self.__ingest_status_api_client.report_status(ingest)
+            if ingest.depositing_application == "Dataverse":
+                self.__ingest_status_api_client.report_status(ingest)
         except (IngestSaveException, ReportStatusApiClientException) as e:
             raise SetIngestAsTransferredException(ingest.package_id, str(e))
 
@@ -110,7 +111,8 @@ class IngestService:
         ingest.status = IngestStatus.transferred_to_dropbox_failed
         try:
             self.__ingest_repository.save(ingest)
-            self.__ingest_status_api_client.report_status(ingest)
+            if ingest.depositing_application == "Dataverse":
+                self.__ingest_status_api_client.report_status(ingest)
         except (IngestSaveException, ReportStatusApiClientException) as e:
             raise SetIngestAsTransferredFailedException(ingest.package_id, str(e))
 
@@ -128,7 +130,8 @@ class IngestService:
         try:
             self.__process_ready_queue_publisher.publish_message(ingest)
             self.__ingest_repository.save(ingest)
-            self.__ingest_status_api_client.report_status(ingest)
+            if ingest.depositing_application == "Dataverse":
+                self.__ingest_status_api_client.report_status(ingest)
         except (MqException, IngestSaveException, ReportStatusApiClientException) as e:
             raise ProcessIngestException(ingest.package_id, str(e))
 
@@ -147,7 +150,8 @@ class IngestService:
         ingest.drs_url = drs_url
         try:
             self.__ingest_repository.save(ingest)
-            self.__ingest_status_api_client.report_status(ingest)
+            if ingest.depositing_application == "Dataverse":
+                self.__ingest_status_api_client.report_status(ingest)
         except (IngestSaveException, ReportStatusApiClientException) as e:
             raise SetIngestAsProcessedException(ingest.package_id, str(e))
 
@@ -163,6 +167,7 @@ class IngestService:
         ingest.status = IngestStatus.batch_ingest_failed
         try:
             self.__ingest_repository.save(ingest)
-            self.__ingest_status_api_client.report_status(ingest)
+            if ingest.depositing_application == "Dataverse":
+                self.__ingest_status_api_client.report_status(ingest)
         except (IngestSaveException, ReportStatusApiClientException) as e:
             raise SetIngestAsProcessedFailedException(ingest.package_id, str(e))

--- a/app/ingest/domain/services/process_service.py
+++ b/app/ingest/domain/services/process_service.py
@@ -44,18 +44,26 @@ class ProcessService:
                 message_body,
                 message_id
             )
+            depositing_application = message_body_transformer.get_message_body_field_value(
+                'application_name',
+                message_body,
+                message_id
+            )
 
             self.__logger.info("Obtaining ingest by the package id of the received message " + package_id + "...")
             ingest = self.__ingest_service.get_ingest_by_package_id(package_id)
 
-            if process_status == "failure":
-                self.__logger.info("Setting ingest as processed failed...")
-                self.__ingest_service.set_ingest_as_processed_failed(ingest)
+            if depositing_application == "ePADD":
                 return
+            elif depositing_application == "Dataverse":
+                if process_status == "failure":
+                    self.__logger.info("Setting ingest as processed failed...")
+                    self.__ingest_service.set_ingest_as_processed_failed(ingest)
+                    return
 
-            self.__logger.info("Setting ingest as processed...")
-            drs_url = message_body_transformer.get_message_body_field_value('drs_url', message_body, message_id)
-            self.__ingest_service.set_ingest_as_processed(ingest, drs_url)
+                self.__logger.info("Setting ingest as processed...")
+                drs_url = message_body_transformer.get_message_body_field_value('drs_url', message_body, message_id)
+                self.__ingest_service.set_ingest_as_processed(ingest, drs_url)
 
         except (MessageBodyFieldException, IngestServiceException) as e:
             raise ProcessStatusMessageHandlingException(message_id, str(e))

--- a/app/ingest/infrastructure/mq/publishers/process_ready_queue_publisher.py
+++ b/app/ingest/infrastructure/mq/publishers/process_ready_queue_publisher.py
@@ -41,9 +41,18 @@ class ProcessReadyQueuePublisher(IProcessReadyQueuePublisher, StompPublisherBase
         elif ingest.depositing_application == "ePADD":
             destination_path = os.path.join(base_dropbox_path, os.getenv('EPADD_DROPBOX_NAME'), "incoming")
 
-        return {
-            'package_id': ingest.package_id,
-            'destination_path': destination_path,
-            'admin_metadata': ingest.admin_metadata,
-            'application_name': ingest.depositing_application
-        }
+        if ingest.dry_run is None:
+            return {
+                'package_id': ingest.package_id,
+                'destination_path': destination_path,
+                'admin_metadata': ingest.admin_metadata,
+                'application_name': ingest.depositing_application
+            }
+        else:
+            return {
+                'package_id': ingest.package_id,
+                'destination_path': destination_path,
+                'admin_metadata': ingest.admin_metadata,
+                'application_name': ingest.depositing_application,
+                'dry_run': ingest.dry_run
+            }

--- a/test/functional/test.env.example
+++ b/test/functional/test.env.example
@@ -1,6 +1,11 @@
 # Application
 GIT_PYTHON_REFRESH=quiet
 
+# Dropboxes
+BASE_DROPBOX_PATH=/home/appuser/dropbox
+DATAVERSE_DROPBOX_NAME=dvndev
+EPADD_DROPBOX_NAME=epadddev_secure
+
 # MongoDB
 MONGODB_HOST_1=test_mongodb
 MONGODB_HOST_2=test_mongodb

--- a/test/integration/ingest/infrastructure/api/test_dataverse_ingest_status_api_client.py
+++ b/test/integration/ingest/infrastructure/api/test_dataverse_ingest_status_api_client.py
@@ -33,7 +33,8 @@ class TestDataverseIngestStatusApiClient(IntegrationTestBase):
         self.__create_test_resources()
 
     def tearDown(self) -> None:
-        self.__delete_test_resources()
+        #self.__delete_test_resources()
+        pass
 
     def test_report_status_happy_path(self) -> None:
         test_package_id = self.__transform_persistent_id_to_dims_package_id()


### PR DESCRIPTION
**Update status call for multiple application use**
* * *

**GitHub Issue**: [epadd#89](https://app.zenhub.com/workspaces/epadd-harvard-62c485cd49f954001312ebdd/issues/harvard-lts/epadd/89)

# What does this Pull Request do?
In order to expand DIMS status calls to multiple applications, in this case ePADD and Dataverse, the status call logic was updated

# How should this be tested?

- Deployed to dev
- Ensure no status call message is sent to Dataverse

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? yes
- integration tests? yes

# Interested parties
@dl-maura 
